### PR TITLE
fix: add feature detection for winbar

### DIFF
--- a/lua/hover/actions.lua
+++ b/lua/hover/actions.lua
@@ -1,6 +1,9 @@
 local util = require('vim.lsp.util')
+local vim = vim
 local api = vim.api
 local npcall = vim.F.npcall
+
+local has_winbar = vim.fn.has('nvim-0.8') == 1
 
 local async = require('hover.async')
 
@@ -16,6 +19,12 @@ local function is_enabled(provider)
 end
 
 local function add_title(winnr, active_provider_id)
+  if not has_winbar then
+    vim.notify_once('hover.nvim: `config.title` requires neovim >= 0.8.0',
+                    vim.log.levels.WARN)
+    return
+  end
+
   local title = {}
 
   for _, p in ipairs(providers) do


### PR DESCRIPTION
:wave:

This adds a gate for the window title functionality so that the plugin can degrade gracefully, since this is an unreleased nvim feature.

I see that the winbar thing was a [recent change](8985eb1). It _might_ be preferable to revert to the old behavior for nvim <0.8 instead of giving up entirely, but I didn't really feel like implementing all of that for something so minor, especially since nvim 0.8 should drop pretty soon.

I'm not a lua noob, but I _am_ a neovim noob, so feel free to correct me on any of this :) And thanks for making this plugin!