### PR TITLE
fix: use nvim_echo to avoid polluting message-history

### DIFF
--- a/lua/hover/actions.lua
+++ b/lua/hover/actions.lua
@@ -75,7 +75,7 @@ end
 
 -- Must be called in async context
 local function run_provider(provider)
-  vim.api.nvim_echo({{'hover.nvim: Running provider: '..provider.name}}, false, {})
+  api.nvim_echo({{'hover.nvim: Running provider: '..provider.name}}, false, {})
   local config = get_config()
   local opts = vim.deepcopy(config.preview_opts)
   opts.focus_id = 'hover'
@@ -117,7 +117,7 @@ M.hover = async.void(function()
       return
     end
   end
-  vim.api.nvim_echo({{'hover.nvim: could not find any hover providers', 'WarningMsg'}}, false, {})
+  api.nvim_echo({{'hover.nvim: could not find any hover providers', 'WarningMsg'}}, false, {})
 end)
 
 M.hover_select = function()

--- a/lua/hover/actions.lua
+++ b/lua/hover/actions.lua
@@ -75,7 +75,7 @@ end
 
 -- Must be called in async context
 local function run_provider(provider)
-  print('hover.nvim: Running provider: '..provider.name)
+  vim.api.nvim_echo({{'hover.nvim: Running provider: '..provider.name}}, false, {})
   local config = get_config()
   local opts = vim.deepcopy(config.preview_opts)
   opts.focus_id = 'hover'
@@ -117,7 +117,7 @@ M.hover = async.void(function()
       return
     end
   end
-  print('hover.nvim: could not find any hover providers')
+  vim.api.nvim_echo({{'hover.nvim: could not find any hover providers', 'WarningMsg'}}, false, {})
 end)
 
 M.hover_select = function()

--- a/lua/hover/providers.lua
+++ b/lua/hover/providers.lua
@@ -9,8 +9,8 @@ local id_cnt = 0
 
 function M.register(provider)
   if not provider.execute or type(provider.execute) ~= 'function' then
-    print(string.format('error: hover provider %s does not provide an execute function',
-      provider.name or 'NA'))
+    vim.notify(string.format('error: hover provider %s does not provide an execute function',
+      provider.name or 'NA'), vim.log.levels.ERROR)
     return
   end
 


### PR DESCRIPTION
I found it a bit disrupting that these particular logs showed up in my
message history, figured it'd make sense to use nvim_echo for this
instead?

Also changed remaining print() to vim.notify() with an appropriate log
level.
