### PR TITLE
fix: increase window height when injecting title line

### DIFF
--- a/lua/hover/actions.lua
+++ b/lua/hover/actions.lua
@@ -36,6 +36,10 @@ local function add_title(winnr, active_provider_id)
   end
 
   vim.wo[winnr].winbar = table.concat(title, '')
+  local config = vim.api.nvim_win_get_config(winnr)
+  vim.api.nvim_win_set_config(winnr, {
+    height = config.height + 1
+  })
 end
 
 local function find_window_by_var(name, value)


### PR DESCRIPTION
The floating window will, by default, have the same size as the amount of lines
in the contents provided to `vim.lsp.util.open_floating_preview`. When setting a winbar
it'll offset the contents by one line cause it to overflow the window height, effectively hiding
the last line.
