### PR TITLE
fix: ensure floating window can fit winbar without overflowing

### DIFF
--- a/lua/hover/actions.lua
+++ b/lua/hover/actions.lua
@@ -26,19 +26,22 @@ local function add_title(winnr, active_provider_id)
   end
 
   local title = {}
+  local winbar_length = 0
 
   for _, p in ipairs(providers) do
     if is_enabled(p) then
       local hl = p.id == active_provider_id and 'TabLineSel' or 'TabLineFill'
       title[#title+1] = string.format('%%#%s# %s ', hl, p.name)
       title[#title+1] = '%#Normal# '
+      winbar_length = winbar_length + #p.name + 2 -- + 2 for whitespace padding
     end
   end
 
   vim.wo[winnr].winbar = table.concat(title, '')
   local config = vim.api.nvim_win_get_config(winnr)
   vim.api.nvim_win_set_config(winnr, {
-    height = config.height + 1
+    height = config.height + 1,
+    width = math.max(config.width, winbar_length + 2) -- + 2 for border
   })
 end
 


### PR DESCRIPTION
When the contents of the floating window is short (horizontally), the winbar will overflow and be cut off. This ensures the floating window is always at least wide enough to cover the winbar.

Before:
<img width="188" alt="Screenshot 2022-09-05 at 20 10 47" src="https://user-images.githubusercontent.com/6705160/188499219-a82b0991-4da4-439c-af30-a253d180a8d3.png">


After:
<img width="201" alt="Screenshot 2022-09-05 at 20 10 07" src="https://user-images.githubusercontent.com/6705160/188499227-e060f526-78ce-4293-affd-8d1f3747f076.png">
