### PR TITLE
fix: Jira provider match not being done in execute

### DIFF
--- a/lua/hover/providers/jira.lua
+++ b/lua/hover/providers/jira.lua
@@ -1,12 +1,14 @@
 local job = require('hover.async.job').job
 
+local issue_pattern = '%u%u+-%d+'
+
 local function enabled()
     -- Match 2 or more uppercase letters followed by a '-' and 1 or more digits.
-    return vim.fn.expand('<cWORD>'):match('%u%u+-%d+') ~= nil
+    return vim.fn.expand('<cWORD>'):match(issue_pattern) ~= nil
 end
 
 local function execute(done)
-    local query = vim.fn.expand('<cWORD>')
+    local query = vim.fn.expand('<cWORD>'):match(issue_pattern)
 
     job({'jira', 'issue', 'view', query, '--plain'}, function(result)
         if result == nil then


### PR DESCRIPTION
At the moment having 'ABC-66:' (for example) is getting through the 'enabled' check but not through the 'execute' because the match is not done there (removing the ':').