### PR TITLE
Prevent focus moving to preview window and bugfix

### DIFF
--- a/lua/hover/actions.lua
+++ b/lua/hover/actions.lua
@@ -91,6 +91,7 @@ end
 
 local function send_to_preview_window()
   local bufnr = api.nvim_get_current_buf()
+  local winid = api.nvim_get_current_win()
   local hover_win = find_window_by_var('hover', bufnr)
   if not hover_win or not api.nvim_win_is_valid(hover_win) then
     return false
@@ -105,13 +106,15 @@ local function send_to_preview_window()
   local pwin = get_preview_window() or create_preview_window()
   local pwin_prev_buf = api.nvim_win_get_buf(pwin)
   api.nvim_win_set_buf(pwin, hover_bufnr)
-  -- Unload the empty buffer created along with preview window
-  if api.nvim_buf_line_count(pwin_prev_buf) == 1 and
+  -- Unload the empty buffer created when creating preview window
+  local bufexist, buflinecnt = pcall(api.nvim_buf_line_count, pwin_prev_buf)
+  if bufexist and buflinecnt == 1 and
     api.nvim_buf_get_lines(pwin_prev_buf, 0, -1, false)[1] == "" then
     api.nvim_buf_delete(pwin_prev_buf, {})
   end
   vim.wo[pwin].winbar = vim.wo[hover_win].winbar
   api.nvim_win_close(hover_win, true)
+  api.nvim_set_current_win(winid)
   return true
 end
 

--- a/lua/hover/actions.lua
+++ b/lua/hover/actions.lua
@@ -106,7 +106,7 @@ local function send_to_preview_window()
   local pwin = get_preview_window() or create_preview_window()
   local pwin_prev_buf = api.nvim_win_get_buf(pwin)
   api.nvim_win_set_buf(pwin, hover_bufnr)
-  -- Unload the empty buffer created when creating preview window
+  -- Unload the empty buffer created along with creating preview window
   local bufexist, buflinecnt = pcall(api.nvim_buf_line_count, pwin_prev_buf)
   if bufexist and buflinecnt == 1 and
     api.nvim_buf_get_lines(pwin_prev_buf, 0, -1, false)[1] == "" then

--- a/lua/hover/actions.lua
+++ b/lua/hover/actions.lua
@@ -106,7 +106,7 @@ local function send_to_preview_window()
   local pwin = get_preview_window() or create_preview_window()
   local pwin_prev_buf = api.nvim_win_get_buf(pwin)
   api.nvim_win_set_buf(pwin, hover_bufnr)
-  -- Unload the empty buffer created along with creating preview window
+  -- Unload the empty buffer created along with preview window
   local bufexist, buflinecnt = pcall(api.nvim_buf_line_count, pwin_prev_buf)
   if bufexist and buflinecnt == 1 and
     api.nvim_buf_get_lines(pwin_prev_buf, 0, -1, false)[1] == "" then


### PR DESCRIPTION
Bugfix:
- `pwin_prev_buf` is not a valid bufnr if sending content to preview window when preview window is already opened