### PR TITLE
feat: add `log_level` option to disable some notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ use {
             -- Whether the contents of a currently open hover window should be moved
             -- to a :h preview-window when pressing the hover keymap.
             preview_window = false,
+            profile = vim.log.levels.INFO,
             title = true
         }
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ use {
             -- Whether the contents of a currently open hover window should be moved
             -- to a :h preview-window when pressing the hover keymap.
             preview_window = false,
-            profile = vim.log.levels.INFO,
+            log_level = vim.log.levels.INFO,
             title = true
         }
 

--- a/lua/hover/actions.lua
+++ b/lua/hover/actions.lua
@@ -140,8 +140,11 @@ end
 ---@async
 ---@param provider Provider
 local function run_provider(provider)
-  api.nvim_echo({{'hover.nvim: Running provider: '..provider.name}}, false, {})
   local config = get_config()
+  if config.profile <= vim.log.levels.INFO then
+    api.nvim_echo({{'hover.nvim: Running provider: '..provider.name}}, false, {})
+  end
+
   local opts = vim.deepcopy(config.preview_opts)
   opts.focus_id = 'hover'
 
@@ -177,13 +180,18 @@ end
 M.hover = async.void(function()
   init()
 
+  local config = get_config()
+
   for _, provider in ipairs(providers) do
     async.scheduler()
     if is_enabled(provider) and run_provider(provider) then
       return
     end
   end
-  api.nvim_echo({{'hover.nvim: could not find any hover providers', 'WarningMsg'}}, false, {})
+
+  if config.profile <= vim.log.levels.WARN then
+    api.nvim_echo({{'hover.nvim: could not find any hover providers', 'WarningMsg'}}, false, {})
+  end
 end)
 
 M.hover_select = function()

--- a/lua/hover/actions.lua
+++ b/lua/hover/actions.lua
@@ -141,7 +141,7 @@ end
 ---@param provider Provider
 local function run_provider(provider)
   local config = get_config()
-  if config.profile <= vim.log.levels.INFO then
+  if config.log_level <= vim.log.levels.INFO then
     api.nvim_echo({{'hover.nvim: Running provider: '..provider.name}}, false, {})
   end
 
@@ -189,7 +189,7 @@ M.hover = async.void(function()
     end
   end
 
-  if config.profile <= vim.log.levels.WARN then
+  if config.log_level <= vim.log.levels.WARN then
     api.nvim_echo({{'hover.nvim: could not find any hover providers', 'WarningMsg'}}, false, {})
   end
 end)

--- a/lua/hover/config.lua
+++ b/lua/hover/config.lua
@@ -7,6 +7,7 @@ local default_config = {
     border = 'single'
   },
   preview_window = false,
+  profile = vim.log.levels.INFO,
   title = true
 }
 

--- a/lua/hover/config.lua
+++ b/lua/hover/config.lua
@@ -7,7 +7,7 @@ local default_config = {
     border = 'single'
   },
   preview_window = false,
-  profile = vim.log.levels.INFO,
+  log_level = vim.log.levels.INFO,
   title = true
 }
 


### PR DESCRIPTION
I don't want provider information output on the command line.

I would like to be able to disable it via `config.option`.

NOTE:

- Should we be able to disable the error output as well?
- Would the default value be `INFO`?