### PR TITLE
Added rails for error only when prompted

### DIFF
--- a/lua/hover/actions.lua
+++ b/lua/hover/actions.lua
@@ -183,7 +183,10 @@ M.hover = async.void(function()
       return
     end
   end
-  api.nvim_echo({{'hover.nvim: could not find any hover providers', 'WarningMsg'}}, false, {})
+  local config = get_config()
+  if config.err_on_nomatch then
+      api.nvim_echo({{'hover.nvim: could not find any hover providers', 'WarningMsg'}}, false, {})
+  end
 end)
 
 M.hover_select = function()

--- a/lua/hover/actions.lua
+++ b/lua/hover/actions.lua
@@ -140,8 +140,10 @@ end
 ---@async
 ---@param provider Provider
 local function run_provider(provider)
-  api.nvim_echo({{'hover.nvim: Running provider: '..provider.name}}, false, {})
   local config = get_config()
+  if not config.quiet then
+    api.nvim_echo({{'hover.nvim: Running provider: '..provider.name}}, false, {})
+  end
   local opts = vim.deepcopy(config.preview_opts)
   opts.focus_id = 'hover'
 
@@ -184,8 +186,8 @@ M.hover = async.void(function()
     end
   end
   local config = get_config()
-  if config.err_on_nomatch then
-      api.nvim_echo({{'hover.nvim: could not find any hover providers', 'WarningMsg'}}, false, {})
+  if not config.quiet then
+    api.nvim_echo({{'hover.nvim: could not find any hover providers', 'WarningMsg'}}, false, {})
   end
 end)
 

--- a/lua/hover/config.lua
+++ b/lua/hover/config.lua
@@ -7,7 +7,7 @@ local default_config = {
     border = 'single'
   },
   preview_window = false,
-  err_on_nomatch = true,
+  quiet = false,
   title = true
 }
 

--- a/lua/hover/config.lua
+++ b/lua/hover/config.lua
@@ -7,6 +7,7 @@ local default_config = {
     border = 'single'
   },
   preview_window = false,
+  err_on_nomatch = true,
   title = true
 }
 


### PR DESCRIPTION
RE: #25 

This adds a configuration option called `quiet` which by default is set to `false` (to keep the current "out of the box" behavior the same).

When set to true this will prevent the api from toss errors into the console. Useful for usecases such as the one described in #25 .