### PR TITLE
fix: `gh` repo pattern

### DIFF
--- a/lua/hover/providers/gh.lua
+++ b/lua/hover/providers/gh.lua
@@ -45,7 +45,7 @@ local execute = async.void(function(done)
 
   local job = require('hover.async.job').job
 
-  local repo, num = word:match('([%w%.-_]+/[%w%.-_]+)#(%d+)')
+  local repo, num = word:match('([%w-]+/[%w%.-_]+)#(%d+)')
   if repo then
     ---@type string[]
     output = job {

--- a/lua/hover/providers/gh.lua
+++ b/lua/hover/providers/gh.lua
@@ -45,7 +45,7 @@ local execute = async.void(function(done)
 
   local job = require('hover.async.job').job
 
-  local repo, num = word:match('(%w+/%w+)#(%d+)')
+  local repo, num = word:match('([%w%.-_]+/[%w%.-_]+)#(%d+)')
   if repo then
     ---@type string[]
     output = job {


### PR DESCRIPTION
Github username can contain `-` and repo name can contain `-`, `_` and `.`.