### PR TITLE
fix: Handle errors and notify users if results can't be retrieved

### DIFF
--- a/lua/hover/actions.lua
+++ b/lua/hover/actions.lua
@@ -151,7 +151,7 @@ local function run_provider(provider)
   end
 
   local result = provider.execute_a()
-  if result then
+  if result and #(result.lines or {}) > 0 then
     async.scheduler()
     show_hover(provider.id, config, result, opts)
     return true

--- a/lua/hover/async/job.lua
+++ b/lua/hover/async/job.lua
@@ -3,23 +3,33 @@ local async = require('hover.async')
 local M = {}
 
 ---@async
----@return string[]
+---@return string|nil stdout result
+---@return string|nil stderr result
 M.job = async.wrap(function(obj, callback)
   ---@type string[]
   local stdout_data = {}
-  local stdout = vim.loop.new_pipe(false)
+  local stdout = assert(vim.loop.new_pipe(false))
+
+  ---@type string[]
+  local stderr_data = {}
+  local stderr = assert(vim.loop.new_pipe(false))
 
   local handle
-  handle = vim.loop.spawn(obj[1], {
+  handle, pid_or_err = vim.loop.spawn(obj[1], {
     args  = vim.list_slice(obj, 2),
-    stdio = { nil, stdout },
+    stdio = { nil, stdout, stderr },
     cwd   = obj.cwd,
     env   = obj.env
   },
-    function()
+    function(code, signal)  -- on_exit
       stdout:close()
+      stderr:close()
+      if code ~= 0 then
+        table.insert(stderr_data, 1, 'Process exited with a non-zero exit code ' .. tostring(code) .. ':\n\n')
+      end
       local stdout_result = #stdout_data > 0 and table.concat(stdout_data) or nil
-      callback(stdout_result)
+      local stderr_result = #stderr_data > 0 and table.concat(stderr_data) or nil
+      callback(stdout_result, stderr_result)
       handle:close()
     end
   )
@@ -30,8 +40,16 @@ M.job = async.wrap(function(obj, callback)
         stdout_data[#stdout_data+1] = data
       end
     end)
+    stderr:read_start(function(err, data)
+      if not err then
+        stderr_data[#stderr_data+1] = data
+      end
+    end)
   else
+    -- command failed, possibly command not found
     stdout:close()
+    stderr:close()
+    callback(nil, pid_or_err .. '\n\ncmd = ' .. table.concat(obj, ' '))
   end
 end, 2)
 


### PR DESCRIPTION
PROBLEM: No error message or barely helpful error messages, such as
`Failed to parse gh result` (which is usually a 404 error, actually).

SOLUTION: Extract stderr of the spawned job process and notify users
the result is nil (e.g., when process failed to launch, exit with
non-zero error code with some error messages).

Example:
- gh: `not-existent-user/404-repo#12345`
  Before: `Failed to parse gh result`
  After: Show error message
  ```
    GraphQL: Could not resolve to a Repository with the name
      'not-existent-user/404-repo'. (repository)
  ```

- gh: `#99990000` (invalid issue number)
  Before: `Failed to parse gh user result`
  After: Show error message
  ```
    GraphQL: Could not resolve to an issue or pull request with the
       number of 99990000. (repository.issue)
  ```
- gh_user: `TODO(this-user-does-not-exist): foo`
  After: hover window with `ERROR: Not Found`

- gh/gh_user: When the command `gh` is not installed,
  Before:
    (no popup happens)
  After:
    `ERROR: Not Found`
