### PR TITLE
LSP provider fixes

### DIFF
--- a/lua/hover/providers/lsp.lua
+++ b/lua/hover/providers/lsp.lua
@@ -6,7 +6,7 @@ require('hover').register {
   name = 'LSP',
   priority = 1000,
   enabled = function()
-    for _, client in pairs(get_clients()) do
+    for _, client in pairs(get_clients({ bufnr = 0 })) do
       if client and client.supports_method('textDocument/hover') then
         return true
       end

--- a/lua/hover/providers/lsp.lua
+++ b/lua/hover/providers/lsp.lua
@@ -14,18 +14,27 @@ require('hover').register {
     return false
   end,
   execute = function(opts, done)
+    local util = require('vim.lsp.util')
+
+    local row, col = unpack(opts.pos)
+    local offset_encoding = util._get_offset_encoding(opts.bufnr)
+    row = row - 1
+    local line = vim.api.nvim_buf_get_lines(opts.bufnr, row, row + 1, true)[1]
+    if line then
+      col = util._str_utfindex_enc(line, col, offset_encoding)
+    end
+
     local params = {
-      textDocument = { uri = vim.uri_from_bufnr(opts.bufnr) },
+      textDocument = util.make_text_document_params(opts.bufnr),
       position = {
-        line = opts.pos[1],
-        character = opts.pos[2]
+        line = row,
+        character = col,
       }
     }
 
     vim.lsp.buf_request_all(0, 'textDocument/hover', params, function(responses)
       for _, response in pairs(responses) do
         if response.result and response.result.contents then
-          local util = require('vim.lsp.util')
           local lines = util.convert_input_to_markdown_lines(response.result.contents)
 
           if not vim.tbl_isempty(lines) then

--- a/lua/hover/util.lua
+++ b/lua/hover/util.lua
@@ -313,7 +313,6 @@ function M.open_floating_preview(contents, bufnr, syntax, opts)
   local width, height = make_floating_popup_size(contents, opts)
 
   local float_option = make_floating_popup_options(width, height, opts)
-  print(vim.inspect(float_option))
   local hover_winid = api.nvim_open_win(floating_bufnr, false, float_option)
   if do_stylize then
     vim.wo[hover_winid].conceallevel = 2


### PR DESCRIPTION
The recent mouse hover feature broke my LSP hovering - hovering on a character acts as if you hovered on the character directly below it. Turns out this is because `vim.api.nvim_win_get_cursor` gives you a 1-indexed row number, but the LSP expects a 0-indexed row number. Before 6f6a3b7d0887436583b4725735fc97dab9c3efd6, `vim.lsp.util.make_position_params` was used, which deals with this, but that is no longer the case.

I've basically copied the code from `vim.lsp.util.make_position_param`, since that also deals with an LSP's `offset_encoding`, which is UTF-16 most of the time so the `position.character` sent to the LSP usually needs to be adjusted.

While figuring all this out, I realised that I had been using a custom LSP provider to fix a minor bug but never bothered to make a PR for it, so I've added that here. The bug is that if you have a hover-enabled LSP attached to a buffer, then open a new empty buffer (ie no LSP attached), running hover on the new buffer will throw a `method textDocument/hover is not supported by any of the servers registered for the current buffer` error, since the LSP provider's enable function checks for hover support in _all_ attached LSP clients, rather than only those attached to the current buffer.

And then I've also removed a debug `print()` that was added in 6f6a3b7d0887436583b4725735fc97dab9c3efd6.

Fixes #45