### PR TITLE
fix: remove debug message

### DIFF
--- a/lua/hover/util.lua
+++ b/lua/hover/util.lua
@@ -313,7 +313,6 @@ function M.open_floating_preview(contents, bufnr, syntax, opts)
   local width, height = make_floating_popup_size(contents, opts)
 
   local float_option = make_floating_popup_options(width, height, opts)
-  print(vim.inspect(float_option))
   local hover_winid = api.nvim_open_win(floating_bufnr, false, float_option)
   if do_stylize then
     vim.wo[hover_winid].conceallevel = 2


### PR DESCRIPTION
6f6a3b7d0887436583b4725735fc97dab9c3efd6 seems to have forgotten to delete the debug statement. The following message will appear every time hover window created.

![image](https://github.com/lewis6991/hover.nvim/assets/6105425/db83f3f1-8757-42cf-9d0c-4cd67dcbdbd9)
