### PR TITLE
fix hover_select: use current buf as default when checking is_enabled

### DIFF
--- a/lua/hover/actions.lua
+++ b/lua/hover/actions.lua
@@ -250,8 +250,10 @@ end)
 function M.hover_select(opts)
   init()
 
+  local bufnr = opts and opts.bufnr or api.nvim_get_current_buf()
+
   vim.ui.select(
-    vim.tbl_filter(is_enabled, providers),
+    vim.tbl_filter(function(provider) return is_enabled(provider, bufnr) end, providers),
     {
       prompt = 'Select hover:',
       format_item = function(provider)


### PR DESCRIPTION
Had the same error as described in the issue, this should fix it.

Resolves: #47 