### PR TITLE
fix: fix divide by zero if content is empty

### DIFF
--- a/lua/hover/util.lua
+++ b/lua/hover/util.lua
@@ -183,7 +183,7 @@ local function make_floating_popup_size(contents, opts)
   local line_widths = {}
 
   if not width then
-    width = 0
+    width = 1 -- not zero, avoid modulo by zero if content is empty
     for i, line in ipairs(contents) do
       line_widths[i] = vim.fn.strdisplaywidth(line)
       width = math.max(line_widths[i], width)


### PR DESCRIPTION
Hey, I get an error complaining about height=nan if LSP is returning empty documentation (which happens occasionally with JDTLS). This should fix it.