### PR TITLE
Add `hover_switch` function and associated documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ use {
         -- Setup keymaps
         vim.keymap.set("n", "K", require("hover").hover, {desc = "hover.nvim"})
         vim.keymap.set("n", "gK", require("hover").hover_select, {desc = "hover.nvim (select)"})
+        vim.keymap.set("n", "<C-p>", function() require("hover").hover_switch("previous") end, {desc = "hover.nvim (previous source)"})
+        vim.keymap.set("n", "<C-n>", function() require("hover").hover_switch("next") end, {desc = "hover.nvim (next source)"})
 
         -- Mouse support
         vim.keymap.set('n', '<MouseMove>', require('hover').hover_mouse, { desc = "hover.nvim (mouse)" })

--- a/lua/hover.lua
+++ b/lua/hover.lua
@@ -15,6 +15,12 @@ function M.hover_select(opts)
   require('hover.actions').hover_select(opts)
 end
 
+--- @param direction string, 'previous' | 'next'
+--- @param opts Hover.Options
+function M.hover_switch(direction, opts)
+  require('hover.actions').hover_switch(direction, opts)
+end
+
 function M.hover_mouse()
   require('hover.actions').hover_mouse()
 end

--- a/lua/hover/actions.lua
+++ b/lua/hover/actions.lua
@@ -250,6 +250,44 @@ M.hover = async.void(function(opts)
   end
 end)
 
+--- @param direction string, 'previous' | 'next'
+--- @param opts Hover.Options
+function M.hover_switch(direction, opts)
+  local bufnr = api.nvim_get_current_buf()
+  local provider_count = 0
+  local provider_idx = 0
+  local active_providers = {}
+  local hover_win = vim.b[bufnr].hover_preview
+  local current_provider =
+    hover_win and
+    api.nvim_win_is_valid(hover_win) and
+    vim.w[hover_win].hover_provider or nil
+
+  for n, p in ipairs(providers) do
+    if p.id == current_provider then
+      provider_idx = provider_count
+    end
+    if is_enabled(p, bufnr) then
+      active_providers[provider_count] = n
+      provider_count = provider_count + 1
+    end
+  end
+
+  if current_provider then
+    if direction == 'previous' then
+      async.void(run_provider)(
+        providers[active_providers[(provider_idx - 1) % provider_count]],
+        opts
+      )
+    elseif direction == 'next' then
+      async.void(run_provider)(
+        providers[active_providers[(provider_idx + 1) % provider_count]],
+        opts
+      )
+    end
+  end
+end
+
 function M.hover_select(opts)
   init()
 


### PR DESCRIPTION
I added a function `hover_switch` that toggles to the next/previous Hover provider in the current window, along with example keybinds in the readme. This was mostly for my own sake, as it was a feature that I thought would be nice to have, but it should also resolve #15.