### PR TITLE
fix(lsp): fix utf-32 being considered as invalid encoding

### DIFF
--- a/lua/hover/providers/lsp.lua
+++ b/lua/hover/providers/lsp.lua
@@ -17,7 +17,7 @@ local function str_utfindex(line, index, encoding)
 
   encoding = encoding or 'utf-16'
 
-  if encoding == 'utf-16' or encoding == 'utf-16' then
+  if encoding == 'utf-16' or encoding == 'utf-32' then
     local col32, col16 = vim.str_utfindex(line, index)
     return encoding == 'utf-32' and col32 or col16
   end


### PR DESCRIPTION
When showing hover information when the LSP is ccls, the plugin returns an error. This PR fixes it.