### PR TITLE
feat: add multiple_hover config option

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*.lua]
+charset = utf-8
+indent_style = space
+indent_size = 2
+quote_style = single
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/README.md
+++ b/README.md
@@ -142,8 +142,8 @@ Call `require('hover').register(<provider>)` with a table containing the followi
 - `execute`: function, executes the hover. Has the following arguments:
     - `opts`: Additional options:
         - `bufnr` (integer)
+        - `winid` (integer)
         - `pos` ({[1]: integer, [2]: integer})
-        - `relative` (string)
     - `done`: callback. First argument should be passed:
         - `nil`/`false` if the hover failed to execute. This will allow other lower priority hovers to run.
         - A table with the following fields:
@@ -174,7 +174,8 @@ require('hover').register {
 ```lua
 --- @class Hover.Options
 --- @field bufnr integer
+--- @field winid integer
+--- (1,0)-based
 --- @field pos {[1]: integer, [2]: integer}
---- @field relative? string
 --- @field providers? string[]
 ```

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Call `require('hover').register(<provider>)` with a table containing the followi
         - `winid` (integer)
         - `pos` ({[1]: integer, [2]: integer})
     - `done`: callback. First argument should be passed:
-        - `nil`/`false` if the hover failed to execute. This will allow other lower priority hovers to run.
+        - `nil` if the hover failed to execute. This will allow other lower priority hovers to run.
         - A table with the following fields:
           - `lines` (string array)
           - `filetype` (string)
@@ -164,7 +164,7 @@ require('hover').register {
      return true
    end,
    --- @param opts Hover.Options
-   --- @param done fun(result: any)
+   --- @param done fun(result?: Hover.Result)
    execute = function(opts, done)
      done{lines={'TEST'}, filetype="markdown"}
    end
@@ -178,4 +178,9 @@ require('hover').register {
 --- (1,0)-based
 --- @field pos {[1]: integer, [2]: integer}
 --- @field providers? string[]
+
+--- @class Hover.Result
+--- @field lines? string[]
+--- @field bufnr? integer
+--- @field filetype? string
 ```

--- a/README.md
+++ b/README.md
@@ -158,16 +158,16 @@ Call `require('hover').register(<provider>)` with a table containing the followi
 ```lua
 -- Simple
 require('hover').register {
-   name = 'Simple',
-   --- @param bufnr integer
-   enabled = function(bufnr)
-     return true
-   end,
-   --- @param opts Hover.Options
-   --- @param done fun(result?: Hover.Result)
-   execute = function(opts, done)
-     done{lines={'TEST'}, filetype="markdown"}
-   end
+  name = 'Simple',
+  --- @param bufnr integer
+  enabled = function(bufnr)
+    return true
+  end,
+  --- @param opts Hover.Options
+  --- @param done fun(result?: Hover.Result)
+  execute = function(opts, done)
+    done { lines = { 'TEST' }, filetype = 'markdown' }
+  end
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -47,9 +47,13 @@ use {
             preview_opts = {
                 border = 'single'
             },
-            -- Whether the contents of a currently open hover window should be moved
-            -- to a :h preview-window when pressing the hover keymap.
-            preview_window = false,
+            -- What to do if hover() is called when a hover popup is already open:
+            -- "cycle_providers" - cycle to the next enabled provider
+            -- "focus" - move the cursor into the popup
+            -- "preview_window" - move the popup contents to a :h preview-window
+            -- "close" - close the popup
+            -- "ignore" - do nothing
+            multiple_hover = "cycle_providers"
             title = true,
             mouse_providers = {
                 'LSP'

--- a/lua/hover.lua
+++ b/lua/hover.lua
@@ -5,18 +5,18 @@ function M.register(provider)
   require('hover.providers').register(provider)
 end
 
---- @param opts Hover.Options
+--- @param opts? Hover.PartialOptions
 function M.hover(opts)
   require('hover.actions').hover(opts)
 end
 
---- @param opts Hover.Options
+--- @param opts? Hover.PartialOptions
 function M.hover_select(opts)
   require('hover.actions').hover_select(opts)
 end
 
---- @param direction string, 'previous' | 'next'
---- @param opts Hover.Options
+--- @param direction 'previous'|'next'
+--- @param opts? Hover.PartialOptions
 function M.hover_switch(direction, opts)
   require('hover.actions').hover_switch(direction, opts)
 end
@@ -29,7 +29,7 @@ function M.close()
   require('hover.actions').close()
 end
 
----@param user_config Hover.Config
+--- @param user_config Hover.Config
 function M.setup(user_config)
   require('hover.config').set(user_config)
 end

--- a/lua/hover.lua
+++ b/lua/hover.lua
@@ -25,9 +25,8 @@ function M.hover_mouse()
   require('hover.actions').hover_mouse()
 end
 
---- @param bufnr integer
-function M.close(bufnr)
-  require('hover.actions').close(bufnr)
+function M.close()
+  require('hover.actions').close()
 end
 
 ---@param user_config Hover.Config

--- a/lua/hover/actions.lua
+++ b/lua/hover/actions.lua
@@ -257,7 +257,7 @@ local function run_cycle_providers(opts, direction)
   end
 end
 
---- @param opts Hover.Options?
+--- @param opts Hover.PartialOptions?
 --- @return Hover.Options
 local function make_opts(opts)
   opts = opts or {}
@@ -273,7 +273,7 @@ local function make_opts(opts)
     opts.pos = opts.pos or api.nvim_win_get_cursor(0)
   end
 
-  return opts
+  return opts --[[@as Hover.Options]]
 end
 
 local function init()
@@ -295,7 +295,7 @@ function M.close()
   end
 end
 
---- @param opts Hover.Options?
+--- @param opts Hover.PartialOptions?
 M.hover = async.void(function(opts)
   init()
 
@@ -338,7 +338,7 @@ M.hover_switch = async.void(function(direction, opts)
   run_cycle_providers(opts, direction)
 end)
 
---- @param opts Hover.Options?
+--- @param opts Hover.PartialOptions?
 function M.hover_select(opts)
   init()
 
@@ -369,7 +369,7 @@ function M.hover_select(opts)
   )
 end
 
-local timer --- @type uv.uv_timer_t
+local timer --- @type uv_timer_t
 
 function M.hover_mouse()
   timer = timer or assert(vim.uv.new_timer())

--- a/lua/hover/actions.lua
+++ b/lua/hover/actions.lua
@@ -1,5 +1,4 @@
 local api = vim.api
-local npcall = vim.F.npcall
 
 local has_winbar = vim.fn.has('nvim-0.8') == 1
 
@@ -11,6 +10,16 @@ local get_config = require('hover.config').get
 local M = {}
 
 local initialised = false
+
+--- @type integer?
+local _hover_win = nil
+
+--- @return integer?
+local function get_hover_win()
+  if _hover_win and api.nvim_win_is_valid(_hover_win) then
+    return _hover_win
+  end
+end
 
 --- @param provider Hover.Provider
 --- @param bufnr integer
@@ -50,40 +59,19 @@ local function add_title(bufnr, winnr, active_provider_id)
   vim.wo[winnr].winbar = table.concat(title, '')
 end
 
----@param name string
----@param value any
----@return integer?
-local function find_window_by_var(name, value)
-  for _, win in ipairs(api.nvim_list_wins()) do
-    if npcall(api.nvim_win_get_var, win, name) == value then
-      return win
-    end
-  end
-end
-
---- @return integer? winid
-local function focus_or_close_floating_window()
-  local bufnr = api.nvim_get_current_buf()
-  local winid = api.nvim_get_current_win()
-
-  -- Go back to previous window if we are in a focusable one
-  if vim.w[winid].hover then
-    vim.cmd.wincmd('p')
-    return winid
+--- @param winid integer
+local function focus_floating_window(winid)
+  if vim.fn.pumvisible() ~= 0 then
+    return
   end
 
-  local win = find_window_by_var('hover', bufnr)
-  if win and api.nvim_win_is_valid(win) and vim.fn.pumvisible() == 0 then
-    -- focus and return the existing buf, win
-    api.nvim_set_current_win(win)
-    vim.cmd.stopinsert()
-    return win
-  end
+  api.nvim_set_current_win(winid)
+  vim.cmd.stopinsert()
 end
 
 --- @return integer?
 local function get_preview_window()
-  for _, win in ipairs(api.nvim_tabpage_list_wins(api.nvim_get_current_tabpage())) do
+  for _, win in ipairs(api.nvim_tabpage_list_wins(0)) do
     if vim.wo[win].previewwindow then
       return win
     end
@@ -92,50 +80,40 @@ end
 
 --- @return integer
 local function create_preview_window()
-  vim.cmd.new()
-  vim.cmd.stopinsert()
+  local curwin = api.nvim_get_current_win()
+
+  -- open a horizontal window with height = previewheight
+  vim.cmd.new({ range = { vim.o.previewheight } })
   local pwin = api.nvim_get_current_win()
   vim.wo[pwin].previewwindow = true
-  api.nvim_win_set_height(pwin, vim.o.previewheight)
+
+  api.nvim_set_current_win(curwin)
+
   return pwin
 end
 
---- @return integer? winid
-local function send_to_preview_window()
-  local bufnr = api.nvim_get_current_buf()
-  local winid = api.nvim_get_current_win()
-  local hover_win = find_window_by_var('hover', bufnr)
-  if not hover_win or not api.nvim_win_is_valid(hover_win) then
-    return
-  end
-  local hover_bufnr = api.nvim_win_get_buf(hover_win)
-  if not hover_bufnr or not api.nvim_buf_is_valid(hover_bufnr) then
-    return
-  end
+--- @param winid integer
+local function send_to_preview_window(winid)
   if vim.fn.pumvisible() ~= 0 then
     return
   end
-  local pwin = get_preview_window() or create_preview_window()
-  local pwin_prev_buf = api.nvim_win_get_buf(pwin)
-  api.nvim_win_set_buf(pwin, hover_bufnr)
-  -- Unload the empty buffer created along with preview window
-  local bufexist, buflinecnt = pcall(api.nvim_buf_line_count, pwin_prev_buf)
-  if bufexist and buflinecnt == 1 and
-    api.nvim_buf_get_lines(pwin_prev_buf, 0, -1, false)[1] == "" then
-    api.nvim_buf_delete(pwin_prev_buf, {})
-  end
-  vim.wo[pwin].winbar = vim.wo[hover_win].winbar
-  api.nvim_win_close(hover_win, true)
-  api.nvim_set_current_win(winid)
-  return pwin
-end
 
---- @return integer? winid
-local function do_hover()
-  if get_config().preview_window then
-    return send_to_preview_window()
+  local bufnr = api.nvim_win_get_buf(winid)
+  local pwin = get_preview_window()
+  if not pwin then
+    pwin = create_preview_window()
+    local pwin_empty_buf = api.nvim_win_get_buf(pwin)
+    api.nvim_win_set_buf(pwin, bufnr)
+    -- Unload the empty buffer created along with preview window
+    api.nvim_buf_delete(pwin_empty_buf, {})
+  else
+    api.nvim_win_set_buf(pwin, bufnr)
   end
-  return focus_or_close_floating_window()
+
+  vim.wo[pwin].winbar = vim.wo[winid].winbar
+  api.nvim_win_close(winid, true)
+
+  return pwin
 end
 
 --- @class Hover.Result
@@ -143,52 +121,159 @@ end
 --- @field bufnr? integer
 --- @field filetype? string
 
---- @param bufnr integer
+--- @param popts Hover.Options
 --- @param provider_id integer
---- @param config Hover.Config
 --- @param result Hover.Result
---- @param opts Hover.Options
---- @return integer hover_winid
-local function show_hover(bufnr, provider_id, config, result, opts)
+local function show_hover(popts, provider_id, result)
+  local config = get_config()
+
+  local opts = vim.deepcopy(config.preview_opts)
+  opts.relative = popts.relative
+
   local util = require('hover.util')
-  local winid = util.open_floating_preview(result.lines, result.bufnr, result.filetype, opts)
+  local hover_win, hover_buf = util.open_floating_preview(result.lines, result.bufnr, result.filetype, opts)
+
+  _hover_win = hover_win
 
   if config.title then
-    add_title(bufnr, winid, provider_id)
+    add_title(popts.bufnr, hover_win, provider_id)
   end
-  vim.w[winid].hover_provider = provider_id
 
-  return winid
+  vim.b[hover_buf].hover = popts.bufnr
+  vim.b[hover_buf].hover_pos = popts.pos
+  vim.b[hover_buf].hover_provider = provider_id
 end
 
 --- @param provider Hover.Provider
 --- @param popts Hover.Options
 --- @return boolean
-local function run_provider(provider, popts)
-  local config = get_config()
-  local opts = vim.deepcopy(config.preview_opts)
-
-  if opts.focusable ~= false and opts.focus ~= false then
-    if do_hover() then
-      return false
-    end
-  end
-
-  popts = popts or {}
-  popts.bufnr = popts.bufnr or api.nvim_get_current_buf()
-  popts.pos = popts.pos or api.nvim_win_get_cursor(0)
-
-  opts.relative = popts.relative
-
+local function do_provider(provider, popts)
   local result = provider.execute_a(popts)
-
   if result then
     async.scheduler()
-    show_hover(popts.bufnr, provider.id, config, result, opts)
+    show_hover(popts, provider.id, result)
     return true
   end
 
   return false
+end
+
+--- @param provider Hover.Provider
+--- @param opts Hover.Options
+local function run_provider(provider, opts)
+  local focus_window = false
+
+  local hover_win = get_hover_win()
+  if hover_win then
+    -- if the popup is focused now, refocus it afterwards
+    if hover_win == api.nvim_get_current_win() then
+      focus_window = true
+    end
+
+    -- close the popup
+    api.nvim_win_close(hover_win, true)
+  end
+
+  do_provider(provider, opts)
+
+  if focus_window then
+    hover_win = get_hover_win()
+    if hover_win then
+      focus_floating_window(hover_win)
+    end
+  end
+end
+
+--- @param opts Hover.Options
+--- @param direction 'previous'|'next'
+local function run_cycle_providers(opts, direction)
+  local focus_window = false
+
+  local current_id
+
+  local hover_win = get_hover_win()
+  if hover_win then
+    local hover_buf = api.nvim_win_get_buf(hover_win)
+    current_id = vim.b[hover_buf].hover_provider
+
+    -- if the popup is focused now, refocus it afterwards
+    if hover_win == api.nvim_get_current_win() then
+      focus_window = true
+    end
+
+    -- close the popup
+    api.nvim_win_close(hover_win, true)
+  end
+
+  local current_idx
+  local active_providers = {} -- zero-indexed
+  local provider_count = 0
+  for _, p in ipairs(providers) do
+    if not opts.providers or vim.tbl_contains(opts.providers, p.name) then
+      if p.id == current_id then
+        current_idx = provider_count
+      end
+      if is_enabled(p, opts.bufnr) then
+        active_providers[provider_count] = p
+        provider_count = provider_count + 1
+      end
+    end
+  end
+
+  if provider_count == 0 then
+    return
+  end
+
+  -- start at current_idx +/- 1, or 0 if current_idx == nil
+  local start_idx = 0
+  if current_idx then
+    if direction == 'previous' then
+      start_idx = (current_idx - 1) % provider_count
+    elseif direction == 'next' then
+      start_idx = (current_idx + 1) % provider_count
+    end
+  end
+
+  -- go forwards/backwards through active_providers until one works
+  -- start at start_idx, wrap around when hitting either end
+  -- exit when we get back to start_idx (no providers worked)
+  local i = start_idx
+  while not do_provider(active_providers[i], opts) do
+    if direction == 'previous' then
+      i = (i - 1) % provider_count
+    elseif direction == 'next' then
+      i = (i + 1) % provider_count
+    end
+    if i == start_idx then
+      return
+    end
+  end
+
+  if focus_window then
+    hover_win = get_hover_win()
+    if hover_win then
+      focus_floating_window(hover_win)
+    end
+  end
+end
+
+--- @param opts Hover.Options?
+--- @return Hover.Options
+local function make_opts(opts)
+  opts = opts or {}
+
+  local hover_win = get_hover_win()
+  if hover_win then
+    -- if a popup already exists, override with its opts
+    local hover_buf = api.nvim_win_get_buf(hover_win)
+    opts.bufnr = vim.b[hover_buf].hover
+    opts.pos = vim.b[hover_buf].hover_pos
+  else
+    opts.bufnr = opts.bufnr or api.nvim_get_current_buf()
+    opts.pos = opts.pos or api.nvim_win_get_cursor(0)
+  end
+
+  return opts
 end
 
 local function init()
@@ -203,105 +288,80 @@ local function init()
   end
 end
 
---- @param bufnr integer
-function M.close(bufnr)
-  local cur_hover = vim.b[bufnr].hover_preview
-  if cur_hover and api.nvim_win_is_valid(cur_hover) then
-    api.nvim_win_close(cur_hover, true)
+function M.close()
+  local hover_win = get_hover_win()
+  if hover_win then
+    api.nvim_win_close(hover_win, true)
   end
-  vim.b[bufnr].hover_preview = nil
 end
 
---- @param opts Hover.Options
+--- @param opts Hover.Options?
 M.hover = async.void(function(opts)
   init()
 
-  local bufnr = opts and opts.bufnr or api.nvim_get_current_buf()
+  opts = make_opts(opts)
 
-  local hover_win = vim.b[bufnr].hover_preview
-  local current_provider =
-    hover_win and
-    api.nvim_win_is_valid(hover_win) and
-    vim.w[hover_win].hover_provider or nil
+  -- hover window exists, and in focus -> cycle providers
+  -- hover window exists, not in focus -> use config.multiple_hover
+  -- else -> cycle providers
 
-  --- If hover is open then set use_provider to false until we cycle to the
-  --- next available provider.
-  local use_provider = current_provider == nil
+  local hover_win = get_hover_win()
+  if hover_win and hover_win ~= api.nvim_get_current_win() then
+    local config = get_config()
 
-  for _, provider in ipairs(providers) do
-    if not opts or not opts.providers or vim.tbl_contains(opts.providers, provider.name) then
-      async.scheduler()
-      if use_provider and is_enabled(provider, bufnr) and run_provider(provider, opts) then
-        return
-      end
-      if provider.id == current_provider then
-        use_provider = true
-      end
+    if config.multiple_hover == 'focus' then
+      focus_floating_window(hover_win)
+      return
+    elseif config.multiple_hover == 'preview_window' then
+      send_to_preview_window(hover_win)
+      return
+    elseif config.multiple_hover == 'close' then
+      api.nvim_win_close(hover_win, true)
+      return
+    elseif config.multiple_hover == 'ignore' then
+      return
     end
+    -- fallthrough if config.multiple_hover == 'cycle_providers'
+    -- (or an invalid string)
   end
 
-  for _, provider in ipairs(providers) do
-    if not opts or not opts.providers or vim.tbl_contains(opts.providers, provider.name) then
-      async.scheduler()
-      if is_enabled(provider, bufnr) and run_provider(provider, opts) then
-        return
-      end
-    end
-  end
+  run_cycle_providers(opts, 'next')
 end)
 
---- @param direction string, 'previous' | 'next'
---- @param opts Hover.Options
-function M.hover_switch(direction, opts)
-  local bufnr = api.nvim_get_current_buf()
-  local provider_count = 0
-  local provider_idx = 0
-  local active_providers = {}
-  local hover_win = vim.b[bufnr].hover_preview
-  local current_provider =
-    hover_win and
-    api.nvim_win_is_valid(hover_win) and
-    vim.w[hover_win].hover_provider or nil
+--- @param direction 'previous'|'next'
+--- @param opts Hover.Options?
+M.hover_switch = async.void(function(direction, opts)
+  init()
 
-  for n, p in ipairs(providers) do
-    if p.id == current_provider then
-      provider_idx = provider_count
-    end
-    if is_enabled(p, bufnr) then
-      active_providers[provider_count] = n
-      provider_count = provider_count + 1
-    end
-  end
+  opts = make_opts(opts)
 
-  if current_provider then
-    if direction == 'previous' then
-      async.void(run_provider)(
-        providers[active_providers[(provider_idx - 1) % provider_count]],
-        opts
-      )
-    elseif direction == 'next' then
-      async.void(run_provider)(
-        providers[active_providers[(provider_idx + 1) % provider_count]],
-        opts
-      )
-    end
-  end
-end
+  run_cycle_providers(opts, direction)
+end)
 
+--- @param opts Hover.Options?
 function M.hover_select(opts)
   init()
 
-  local bufnr = opts and opts.bufnr or api.nvim_get_current_buf()
+  opts = make_opts(opts)
+
+  local active_providers = vim.tbl_filter(function(p)
+    if not opts or not opts.providers or vim.tbl_contains(opts.providers, p.name) then
+      if is_enabled(p, opts.bufnr) then
+        return true
+      end
+    end
+    return false
+  end, opts and opts.providers or providers)
 
   vim.ui.select(
-    vim.tbl_filter(function(provider) return is_enabled(provider, bufnr) end, providers),
+    active_providers,
     {
       prompt = 'Select hover:',
       format_item = function(provider)
         return provider.name
       end
     },
-    function (provider)
+    function(provider)
       if provider then
         async.void(run_provider)(provider, opts)
       end
@@ -323,7 +383,16 @@ function M.hover_mouse()
     local buf = vim.fn.winbufnr(pos.winid)
     if buf == -1 then return end
 
-    M.close(buf)
+    -- don't trigger if hovering in the popup window
+    local hover_win = get_hover_win()
+    if hover_win then
+      local hover_buf = api.nvim_win_get_buf(hover_win)
+      if buf == hover_buf then
+        return
+      end
+    end
+
+    M.close()
 
     M.hover {
       providers = config.mouse_providers,

--- a/lua/hover/actions.lua
+++ b/lua/hover/actions.lua
@@ -28,37 +28,6 @@ local function is_enabled(provider, bufnr)
   return provider.enabled == nil or provider.enabled(bufnr)
 end
 
---- @param bufnr integer
---- @param winnr integer
---- @param active_provider_id integer
-local function add_title(bufnr, winnr, active_provider_id)
-  if not has_winbar then
-    vim.notify_once('hover.nvim: `config.title` requires neovim >= 0.8.0',
-                    vim.log.levels.WARN)
-    return
-  end
-
-  ---@type string[]
-  local title = {}
-  local winbar_length = 0
-
-  for _, p in ipairs(providers) do
-    if is_enabled(p, bufnr) then
-      local hl = p.id == active_provider_id and 'TabLineSel' or 'TabLineFill'
-      title[#title+1] = string.format('%%#%s# %s ', hl, p.name)
-      title[#title+1] = '%#Normal# '
-      winbar_length = winbar_length + #p.name + 2 -- + 2 for whitespace padding
-    end
-  end
-
-  local config = api.nvim_win_get_config(winnr)
-  api.nvim_win_set_config(winnr, {
-    height = config.height + 1,
-    width = math.max(config.width, winbar_length + 2) -- + 2 for border
-  })
-  vim.wo[winnr].winbar = table.concat(title, '')
-end
-
 --- @param winid integer
 local function focus_floating_window(winid)
   if vim.fn.pumvisible() ~= 0 then
@@ -121,6 +90,36 @@ end
 --- @field bufnr? integer
 --- @field filetype? string
 
+--- @param bufnr integer
+--- @param active_provider_id integer
+--- @return string? winbar, integer length
+local function make_winbar(bufnr, active_provider_id)
+  -- TODO: check this?
+
+  if not has_winbar then
+    vim.notify_once('hover.nvim: `config.title` requires neovim >= 0.8.0',
+      vim.log.levels.WARN)
+    return nil, 0
+  end
+
+  --- @type string[]
+  local title = {}
+  local winbar_length = 0
+
+  for _, p in ipairs(providers) do
+    if is_enabled(p, bufnr) then
+      local hl = p.id == active_provider_id and 'TabLineSel' or 'TabLineFill'
+      title[#title + 1] = string.format('%%#%s# %s %%#Normal#', hl, p.name)
+      winbar_length = winbar_length + #p.name + 2 -- + 2 for padding
+    end
+  end
+
+  local winbar = table.concat(title, ' ')
+  winbar_length = winbar_length + (#title - 1) -- (len - 1) separators
+
+  return winbar, winbar_length
+end
+
 --- @param popts Hover.Options
 --- @param provider_id integer
 --- @param result Hover.Result
@@ -133,14 +132,16 @@ local function show_hover(popts, provider_id, result)
   opts.row = sp.row - 1
   opts.col = sp.curscol - 1
 
+  if config.title then
+    local winbar, winbar_length = make_winbar(popts.bufnr, provider_id)
+    opts.winbar = winbar
+    opts.winbar_length = winbar_length
+  end
+
   local util = require('hover.util')
   local hover_win, hover_buf = util.open_floating_preview(result.lines, result.bufnr, result.filetype, opts)
 
   _hover_win = hover_win
-
-  if config.title then
-    add_title(popts.bufnr, hover_win, provider_id)
-  end
 
   vim.b[hover_buf].hover = popts.bufnr
   vim.b[hover_buf].hover_win = popts.winid

--- a/lua/hover/config.lua
+++ b/lua/hover/config.lua
@@ -6,6 +6,7 @@ local default_config = {
   preview_opts = {
     border = 'single'
   },
+  multiple_hover = 'cycle_providers',
   preview_window = false,
   title = true,
   mouse_providers = { 'LSP' },

--- a/lua/hover/config.lua
+++ b/lua/hover/config.lua
@@ -1,7 +1,12 @@
 local M = {}
 
 --- @class Hover.Config
---- @field init fun()
+--- @field init? fun()
+--- @field preview_opts table
+--- @field multiple_hover "cycle_providers"|"focus"|"preview_window"|"close"|"ignore"
+--- @field title boolean
+--- @field mouse_providers string[]
+--- @field mouse_delay integer
 local default_config = {
   preview_opts = {
     border = 'single'

--- a/lua/hover/providers.lua
+++ b/lua/hover/providers.lua
@@ -4,14 +4,16 @@ local M  = {}
 
 --- @class Hover.PartialOptions
 --- @field bufnr? integer
+--- @field winid? integer
+--- (1,0)-based
 --- @field pos? {[1]: integer, [2]: integer}
---- @field relative? string
 --- @field providers? string[]
 
 --- @class Hover.Options: Hover.PartialOptions
 --- @field bufnr integer
+--- @field winid integer
+--- (1,0)-based
 --- @field pos {[1]: integer, [2]: integer}
---- @field relative? string
 --- @field providers? string[]
 
 --- @class Hover.RegisterProvider

--- a/lua/hover/providers.lua
+++ b/lua/hover/providers.lua
@@ -19,12 +19,12 @@ local M  = {}
 --- @class Hover.RegisterProvider
 --- @field priority integer
 --- @field name string
---- @field execute fun(opts?: Hover.Options, done: fun(result?: Hover.Result))
+--- @field execute fun(opts: Hover.Options, done: fun(result?: Hover.Result))
 --- @field enabled fun(bufnr: integer): boolean
 
 --- @class Hover.Provider: Hover.RegisterProvider
 --- @field id integer
---- @field execute_a fun(opts?: Hover.Options): Hover.Result
+--- @field execute_a fun(opts: Hover.Options): Hover.Result?
 
 --- @type Hover.Provider[]
 local providers = {}

--- a/lua/hover/providers.lua
+++ b/lua/hover/providers.lua
@@ -2,7 +2,13 @@ local async = require('hover.async')
 
 local M  = {}
 
---- @class Hover.Options
+--- @class Hover.PartialOptions
+--- @field bufnr? integer
+--- @field pos? {[1]: integer, [2]: integer}
+--- @field relative? string
+--- @field providers? string[]
+
+--- @class Hover.Options: Hover.PartialOptions
 --- @field bufnr integer
 --- @field pos {[1]: integer, [2]: integer}
 --- @field relative? string
@@ -14,7 +20,7 @@ local M  = {}
 --- @field execute fun(opts?: Hover.Options, done: fun(result?: Hover.Result))
 --- @field enabled fun(bufnr: integer): boolean
 
---- @class Hover.Provider : Hover.RegisterProvider
+--- @class Hover.Provider: Hover.RegisterProvider
 --- @field id integer
 --- @field execute_a fun(opts?: Hover.Options): Hover.Result
 

--- a/lua/hover/providers.lua
+++ b/lua/hover/providers.lua
@@ -1,6 +1,6 @@
 local async = require('hover.async')
 
-local M  = {}
+local M = {}
 
 --- @class Hover.PartialOptions
 --- @field bufnr? integer
@@ -54,7 +54,7 @@ function M.register(provider)
       end
     end
   end
-  providers[#providers+1] = provider
+  providers[#providers + 1] = provider
 end
 
 return M

--- a/lua/hover/providers/dap.lua
+++ b/lua/hover/providers/dap.lua
@@ -4,7 +4,7 @@ local ui = require('dap.ui')
 local widgets = require('dap.ui.widgets')
 local hover = require('hover')
 
-local function find_window (buf)
+local function find_window(buf)
   for _, win in ipairs(vim.api.nvim_list_wins()) do
     if vim.api.nvim_win_get_buf(win) == buf then
       return win
@@ -47,15 +47,15 @@ end
 
 local function set_default_bufopts(buf)
   vim.bo[buf].modifiable = false
-  vim.bo[buf].buftype = "nofile"
+  vim.bo[buf].buftype = 'nofile'
   api.nvim_buf_set_keymap(
-    buf, "n", "<CR>", "<Cmd>lua require('dap.ui').trigger_actions({ mode = 'first' })<CR>", {})
+    buf, 'n', '<CR>', "<Cmd>lua require('dap.ui').trigger_actions({ mode = 'first' })<CR>", {})
   api.nvim_buf_set_keymap(
-    buf, "n", "a", "<Cmd>lua require('dap.ui').trigger_actions()<CR>", {})
+    buf, 'n', 'a', "<Cmd>lua require('dap.ui').trigger_actions()<CR>", {})
   api.nvim_buf_set_keymap(
-    buf, "n", "o", "<Cmd>lua require('dap.ui').trigger_actions()<CR>", {})
+    buf, 'n', 'o', "<Cmd>lua require('dap.ui').trigger_actions()<CR>", {})
   api.nvim_buf_set_keymap(
-    buf, "n", "<2-LeftMouse>", "<Cmd>lua require('dap.ui').trigger_actions()<CR>", {})
+    buf, 'n', '<2-LeftMouse>', "<Cmd>lua require('dap.ui').trigger_actions()<CR>", {})
 end
 
 local function new_buf()
@@ -67,13 +67,13 @@ end
 hover.register {
   name = 'DAP',
   enabled = function(bufnr)
-    return dap.status() ~= ""
+    return dap.status() ~= ''
   end,
   execute = function(opts, done)
     local buf = new_buf()
     local layer = resizing_layer(buf)
     local fake_view = {
-      layer = function ()
+      layer = function()
         return layer
       end,
     }

--- a/lua/hover/providers/dap.lua
+++ b/lua/hover/providers/dap.lua
@@ -66,12 +66,9 @@ end
 
 hover.register {
   name = 'DAP',
-  --- @param bufnr integer
   enabled = function(bufnr)
     return dap.status() ~= ""
   end,
-  --- @param opts Hover.Options
-  --- @param done fun(result: any)
   execute = function(opts, done)
     local buf = new_buf()
     local layer = resizing_layer(buf)

--- a/lua/hover/providers/dictionary.lua
+++ b/lua/hover/providers/dictionary.lua
@@ -34,7 +34,9 @@ end
 
 local cache = {} --- @type table<string,string[]>
 
-local execute = async.void(function(_opts, done)
+--- @param opts Hover.Options
+--- @param done fun(result?: Hover.Result)
+local execute = async.void(function(opts, done)
   local word = vim.fn.expand('<cword>')
 
   if not cache[word] then

--- a/lua/hover/providers/dictionary.lua
+++ b/lua/hover/providers/dictionary.lua
@@ -22,10 +22,10 @@ local function process(result)
   }
 
   for _, def in ipairs(json.meanings[1].definitions) do
-    lines[#lines+1] = ''
-    lines[#lines+1] = def.definition
+    lines[#lines + 1] = ''
+    lines[#lines + 1] = def.definition
     if def.example then
-      lines[#lines+1] = 'Example: '..def.example
+      lines[#lines + 1] = 'Example: ' .. def.example
     end
   end
 
@@ -44,14 +44,14 @@ local execute = async.void(function(opts, done)
 
     ---@type string[]
     local output = job {
-      'curl', 'https://api.dictionaryapi.dev/api/v2/entries/en/'..word
+      'curl', 'https://api.dictionaryapi.dev/api/v2/entries/en/' .. word
     }
 
-    local results = process(output) or {'no definition for '..word}
+    local results = process(output) or { 'no definition for ' .. word }
     cache[word] = results
   end
 
-  done({lines=cache[word], filetype="markdown"})
+  done({ lines = cache[word], filetype = 'markdown' })
 end)
 
 require('hover').register {

--- a/lua/hover/providers/gh.lua
+++ b/lua/hover/providers/gh.lua
@@ -39,6 +39,8 @@ local function process(result, stderr)
   return lines
 end
 
+--- @param opts Hover.Options
+--- @param done fun(result?: Hover.Result)
 local execute = async.void(function(opts, done)
   local bufnr = api.nvim_get_current_buf()
   local cwd = fn.fnamemodify(api.nvim_buf_get_name(bufnr), ':p:h')
@@ -67,7 +69,7 @@ local execute = async.void(function(opts, done)
         cwd = cwd
       }
     else
-      done(false)
+      done()
       return
     end
   end

--- a/lua/hover/providers/gh.lua
+++ b/lua/hover/providers/gh.lua
@@ -10,14 +10,14 @@ end
 ---@param stderr string|nil
 local function process(result, stderr)
   if result == nil then
-    vim.notify(vim.trim(stderr or "(Unknown error)"), vim.log.levels.ERROR, { title = "hover.nvim (gh)" })
+    vim.notify(vim.trim(stderr or '(Unknown error)'), vim.log.levels.ERROR, { title = 'hover.nvim (gh)' })
     return
   end
 
   local ok, json = pcall(vim.json.decode, result)
   if not ok then
     async.scheduler()
-    vim.notify("Failed to parse gh result: " .. json, vim.log.levels.ERROR)
+    vim.notify('Failed to parse gh result: ' .. json, vim.log.levels.ERROR)
     return
   end
 
@@ -33,7 +33,7 @@ local function process(result, stderr)
   }
 
   for _, l in ipairs(vim.split(json.body, '\r?\n')) do
-    lines[#lines+1] = l
+    lines[#lines + 1] = l
   end
 
   return lines
@@ -75,7 +75,7 @@ local execute = async.void(function(opts, done)
   end
 
   local results = process(output, stderr)
-  done(results and {lines=results, filetype="markdown"})
+  done(results and { lines = results, filetype = 'markdown' })
 end)
 
 require('hover').register {

--- a/lua/hover/providers/gh_user.lua
+++ b/lua/hover/providers/gh_user.lua
@@ -69,12 +69,14 @@ local function process(result, stderr)
   return res
 end
 
+--- @param opts Hover.Options
+--- @param done fun(result?: Hover.Result)
 local execute = async.void(function(opts, done)
   local bufnr = api.nvim_get_current_buf()
   local cwd = fn.fnamemodify(api.nvim_buf_get_name(bufnr), ':p:h')
   local user = get_user()
   if not user then
-    done(false)
+    done()
   end
   local job = require('hover.async.job').job
 

--- a/lua/hover/providers/gh_user.lua
+++ b/lua/hover/providers/gh_user.lua
@@ -15,21 +15,21 @@ local function enabled()
 end
 
 local function first_to_upper(str)
-  return str:gsub("^%l", string.upper)
+  return str:gsub('^%l', string.upper)
 end
 
 ---@param result string|nil
 ---@param stderr string|nil
 local function process(result, stderr)
   if result == nil then
-    vim.notify(vim.trim(stderr or "(Unknown error)"), vim.log.levels.ERROR, { title = "hover.nvim (gh_user)" })
+    vim.notify(vim.trim(stderr or '(Unknown error)'), vim.log.levels.ERROR, { title = 'hover.nvim (gh_user)' })
     return
   end
 
   local ok, json = pcall(vim.json.decode, result)
   if not ok then
     async.scheduler()
-    vim.notify("Failed to parse gh user result" .. json, vim.log.levels.ERROR)
+    vim.notify('Failed to parse gh user result' .. json, vim.log.levels.ERROR)
     return
   end
 
@@ -50,20 +50,20 @@ local function process(result, stderr)
   } do
     local field = json[key]
     if field and field ~= vim.NIL then
-      res[#res+1] = string.format('**%s**: `%s`', first_to_upper(key), field)
+      res[#res + 1] = string.format('**%s**: `%s`', first_to_upper(key), field)
     end
   end
 
   if json.bio and json.bio ~= vim.NIL then
-      res[#res+1] = '**Bio**:'
+    res[#res + 1] = '**Bio**:'
     for _, l in ipairs(vim.split(json.bio:gsub('\r', ''), '\n')) do
-      res[#res+1] = '>  '..l
+      res[#res + 1] = '>  ' .. l
     end
   end
 
   -- 404 (user does not exist)
   if #res == 0 and json.message and json.message ~= vim.NIL then
-    res[#res+1] = 'ERROR: ' .. json.message
+    res[#res + 1] = 'ERROR: ' .. json.message
   end
 
   return res
@@ -82,10 +82,10 @@ local execute = async.void(function(opts, done)
 
   ---@type string
   local output, stderr
-  output, stderr = job { 'gh', 'api', 'users/'..user, cwd = cwd }
+  output, stderr = job { 'gh', 'api', 'users/' .. user, cwd = cwd }
 
   local results = process(output, stderr)
-  done(results and {lines=results, filetype="markdown"})
+  done(results and { lines = results, filetype = 'markdown' })
 end)
 
 require('hover').register {

--- a/lua/hover/providers/jira.lua
+++ b/lua/hover/providers/jira.lua
@@ -5,6 +5,8 @@ local function enabled()
     return vim.fn.expand('<cWORD>'):match(ISSUE_PATTERN) ~= nil
 end
 
+--- @param opts Hover.Options
+--- @param done fun(result?: Hover.Result)
 local function execute(opts, done)
     local query = vim.fn.expand('<cWORD>'):match(ISSUE_PATTERN)
 
@@ -12,7 +14,7 @@ local function execute(opts, done)
 
     job({'jira', 'issue', 'view', query, '--plain'}, function(result)
         if result == nil then
-            done(false)
+            done()
             return
         end
 

--- a/lua/hover/providers/jira.lua
+++ b/lua/hover/providers/jira.lua
@@ -1,40 +1,39 @@
+-- Match 2 or more uppercase letters followed by a '-' and 1 or more digits.
 local ISSUE_PATTERN = '%u[%u%d]+-%d+'
 
 local function enabled()
-    -- Match 2 or more uppercase letters followed by a '-' and 1 or more digits.
-    return vim.fn.expand('<cWORD>'):match(ISSUE_PATTERN) ~= nil
+  return vim.fn.expand('<cWORD>'):match(ISSUE_PATTERN) ~= nil
 end
 
 --- @param opts Hover.Options
 --- @param done fun(result?: Hover.Result)
 local function execute(opts, done)
-    local query = vim.fn.expand('<cWORD>'):match(ISSUE_PATTERN)
+  local query = vim.fn.expand('<cWORD>'):match(ISSUE_PATTERN)
 
-    local job = require('hover.async.job').job
+  local job = require('hover.async.job').job
 
-    job({'jira', 'issue', 'view', query, '--plain'}, function(result)
-        if result == nil then
-            done()
-            return
-        end
+  job({ 'jira', 'issue', 'view', query, '--plain' }, function(result)
+    if result == nil then
+      done()
+      return
+    end
 
-        local lines = {}
-        for line in result:gmatch('[^\r\n]+') do
-            -- Remove lines starting with \27, which is not formatted well and
-            -- is only there for help/context/suggestion lines anyway.
-            if line:find('^\27') == nil then
-                table.insert(lines, line)
-            end
-        end
+    local lines = {}
+    for line in result:gmatch('[^\r\n]+') do
+      -- Remove lines starting with \27, which is not formatted well and
+      -- is only there for help/context/suggestion lines anyway.
+      if line:find('^\27') == nil then
+        table.insert(lines, line)
+      end
+    end
 
-        done {lines = lines, filetype = 'markdown'}
-    end)
+    done { lines = lines, filetype = 'markdown' }
+  end)
 end
 
 require('hover').register {
-    name = 'Jira',
-    priority = 175,
-    enabled = enabled,
-    execute = execute
+  name = 'Jira',
+  priority = 175,
+  enabled = enabled,
+  execute = execute
 }
-

--- a/lua/hover/providers/lsp.lua
+++ b/lua/hover/providers/lsp.lua
@@ -27,7 +27,7 @@ end
 
 --- @param bufnr integer
 --- @param method string
---- @param params_fn fun(client: lsp.Client): table
+--- @param params_fn fun(client: vim.lsp.Client): table
 --- @param handler fun(results: any[])
 local function buf_request_all(bufnr, method, params_fn, handler)
   local results = {}
@@ -51,7 +51,7 @@ end
 --- @param bufnr integer
 --- @param row integer
 --- @param col integer
---- @return fun(client: lsp.Client): table
+--- @return fun(client: vim.lsp.Client): table
 local function create_params(bufnr, row, col)
   return function(client)
       local offset_encoding = client.offset_encoding

--- a/lua/hover/providers/lsp.lua
+++ b/lua/hover/providers/lsp.lua
@@ -1,4 +1,3 @@
-
 --- @diagnostic disable-next-line:deprecated
 local get_clients = vim.lsp.get_clients or vim.lsp.get_active_clients
 
@@ -54,22 +53,22 @@ end
 --- @return fun(client: vim.lsp.Client): table
 local function create_params(bufnr, row, col)
   return function(client)
-      local offset_encoding = client.offset_encoding
-      local ok, lines = pcall(vim.api.nvim_buf_get_lines, bufnr, row, row + 1, true)
+    local offset_encoding = client.offset_encoding
+    local ok, lines = pcall(vim.api.nvim_buf_get_lines, bufnr, row, row + 1, true)
 
-      if not ok then
-        print(debug.traceback(string.format('ERROR: row %d is out of range: %s', row, lines)))
-      end
+    if not ok then
+      print(debug.traceback(string.format('ERROR: row %d is out of range: %s', row, lines)))
+    end
 
-      local ccol = lines and str_utfindex(lines[1], col, offset_encoding) or col
+    local ccol = lines and str_utfindex(lines[1], col, offset_encoding) or col
 
-      return {
-        textDocument = { uri = vim.uri_from_bufnr(bufnr) },
-        position = {
-          line = row,
-          character = ccol
-        }
+    return {
+      textDocument = { uri = vim.uri_from_bufnr(bufnr) },
+      position = {
+        line = row,
+        character = ccol
       }
+    }
   end
 end
 
@@ -97,7 +96,7 @@ require('hover').register {
           if result.contents then
             local lines = util.convert_input_to_markdown_lines(result.contents)
             if not vim.tbl_isempty(lines) then
-              done{lines=lines, filetype="markdown"}
+              done { lines = lines, filetype = 'markdown' }
               return
             end
           end

--- a/lua/hover/providers/man.lua
+++ b/lua/hover/providers/man.lua
@@ -10,6 +10,8 @@ local function enabled(bufnr)
   }, vim.bo[bufnr].filetype)
 end
 
+--- @param opts Hover.Options
+--- @param done fun(result?: Hover.Result)
 local execute = async.void(function(opts, done)
   local word = vim.fn.expand('<cword>')
   local section = vim.bo[opts.bufnr].filetype == 'tcl' and 'n' or '1'

--- a/lua/hover/providers/man.lua
+++ b/lua/hover/providers/man.lua
@@ -25,7 +25,7 @@ local execute = async.void(function(opts, done)
   end)
 
   if not ok or api.nvim_buf_line_count(bufnr) <= 1 then
-    api.nvim_buf_delete(bufnr, {force = true})
+    api.nvim_buf_delete(bufnr, { force = true })
     done()
     return
   end
@@ -39,7 +39,7 @@ local execute = async.void(function(opts, done)
     end
   })
 
-  done{ bufnr = bufnr }
+  done { bufnr = bufnr }
 end)
 
 require('hover').register {

--- a/lua/hover/util.lua
+++ b/lua/hover/util.lua
@@ -70,8 +70,8 @@ local default_border = {
 
 --- @param width integer
 --- @param height integer
---- @param opts vim.api.keyset.float_config
---- @return vim.api.keyset.float_config
+--- @param opts vim.api.keyset.win_config
+--- @return vim.api.keyset.win_config
 local function make_floating_popup_options(width, height, opts)
   opts = opts or {}
 

--- a/lua/hover/util.lua
+++ b/lua/hover/util.lua
@@ -57,13 +57,13 @@ local function trim_empty_lines(lines)
 end
 
 local default_border = {
-  { '' , 'NormalFloat' },
-  { '' , 'NormalFloat' },
-  { '' , 'NormalFloat' },
+  { '',  'NormalFloat' },
+  { '',  'NormalFloat' },
+  { '',  'NormalFloat' },
   { ' ', 'NormalFloat' },
-  { '' , 'NormalFloat' },
-  { '' , 'NormalFloat' },
-  { '' , 'NormalFloat' },
+  { '',  'NormalFloat' },
+  { '',  'NormalFloat' },
+  { '',  'NormalFloat' },
   { ' ', 'NormalFloat' },
 }
 

--- a/lua/hover/util.lua
+++ b/lua/hover/util.lua
@@ -177,6 +177,10 @@ local function make_floating_popup_size(contents, opts)
     end
   end
 
+  if opts.winbar_length then
+    width = math.max(width, opts.winbar_length)
+  end
+
   local wrap_at
   if width > max_width then
     width = max_width
@@ -200,6 +204,10 @@ local function make_floating_popup_size(contents, opts)
         end
       end
     end
+  end
+
+  if opts.winbar then
+    height = height + 1
   end
 
   if max_height then
@@ -303,6 +311,10 @@ function M.open_floating_preview(contents, bufnr, syntax, opts)
 
   local float_option = make_floating_popup_options(width, height, opts)
   local hover_winid = api.nvim_open_win(floating_bufnr, false, float_option)
+
+  if opts.winbar then
+    vim.wo[hover_winid].winbar = opts.winbar
+  end
 
   if do_stylize then
     vim.wo[hover_winid].conceallevel = 2


### PR DESCRIPTION
This adds a `multiple_hover` config option to configure what happens when `hover()` is called while a popup window is already open. This allows for a solution to #49 while retaining the current behaviour of cycling providers for those that prefer that. It is also once again possible to move the popup to a `preview_window` by using this option.

Also, when `hover()` is called while the cursor is _inside_ the popup window, it will always cycle the providers.

I ended up rewriting a fair bit of the main popup logic while fixing a bunch of corner-case issues I found, I'd like to think it's simpler now than it was before. If you need explanations for why I made some specific change then feel free to ask.

The `close()` function no longer requires a bufnr argument, which I believe means #36 can be closed. This is possible because the winid of the popup window is now stored in a Lua "global" variable rather than in a Vim buffer-local variable. It was never really possible for multiple hover popups to be open simultaneously anyway.

And then I've added an `.editorconfig` file and formatted everything so that the indentation and `'` usage is consistent. I'm happy to split that into another PR or revert it completely if needed.

Resolves #19
Resolves #36
Resolves #49