### PR TITLE
Allow GH user to exist without having TODO before it

### DIFF
--- a/lua/hover/providers/gh_user.lua
+++ b/lua/hover/providers/gh_user.lua
@@ -5,7 +5,7 @@ local async = require('hover.async')
 ---@return string
 local function get_user()
   local WORD = fn.expand('<cWORD>')
-  local user = WORD:match('TODO%(@?(.*)%):')
+  local user = WORD:match '%f[%w_]@?(.*)%f[^%w_]'
   return user
 end
 


### PR DESCRIPTION
I dunno what's the reason for having `TODO(@user)` or `TODO(user)` as a requirement to get GH user information, but I don't think that's needed, and making it generic will allow it to work more contexts (including `TODO`). What do you think?