### PR TITLE
bug(dap): hover breaks after ended dap session

### DIFF
--- a/lua/hover/providers/dap.lua
+++ b/lua/hover/providers/dap.lua
@@ -68,7 +68,7 @@ hover.register {
   name = 'DAP',
   --- @param bufnr integer
   enabled = function(bufnr)
-    return dap.status() ~= ""
+    return dap.session()
   end,
   --- @param opts Hover.Options
   --- @param done fun(result: any)

--- a/lua/hover/providers/dap.lua
+++ b/lua/hover/providers/dap.lua
@@ -38,7 +38,7 @@ local function resizing_layer(buf)
   layer.render = function(...)
     orig_render(...)
     local win = find_window(buf)
-    if api.nvim_win_get_config(win).relative ~= '' then
+    if win ~= nil and api.nvim_win_get_config(win).relative ~= '' then
       resize_window(win, buf)
     end
   end


### PR DESCRIPTION
I have been using the dap hover for a while and noticed that it does not delete the buffer on close, searching for a window to resize. As I said, someone should allow to manage the window, either hover.nvim or nvim-dap to implement this hover without ugly copypasta. Here is temporary workaround to fix dap completely breaking hover if the session is closed.

Tested it on python dap with following steps:
1. Open some python script
2. Put a breakpoint somewhere
3. (Optional) Perform hover with LSP
4. Launch Debug session
5. Perform hover with DAP
6. Terminate the session
7. Try to perform hover again (DAP was breaking this step)

The PR is marked as draft because the buffer is not deleted when closing the DAP hover and ending session. That could be the inacceptable behavior

Also the previous PR was merged as-is and I tend to split the development into separate commits. Maybe it would be better to squash or merge this PR.