### PR TITLE
Add custom highlight groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,21 @@ end, { desc = 'hover.nvim (mouse)' })
 vim.o.mousemoveevent = true
 ```
 
+## Appearance
+
+The appearance of the hover window can be customized with the following
+highlight groups:
+
+* `HoverWindow` (defaults to: `NormalFloat`)
+* `HoverBorder` (defaults to: `FloatBorder`)
+* `HoverSourceLine` (defaults to: `TabLine`)
+* `HoverActiveSource` (defaults to: `TabLineSel`)
+* `HoverInactiveSource` (defaults to: `TabLineFill`)
+* `HoverFloatingError` (defaults to: `DiagnosticFloatingError`)
+* `HoverFloatingWarn` (defaults to: `DiagnosticFloatingWarn`)
+* `HoverFloatingInfo` (defaults to: `DiagnosticFloatingInfo`)
+* `HoverFloatingHint` (defaults to: `DiagnosticFloatingHint`)
+
 ### Customising providers
 
 Note: Only supported for providers created with passive registration.

--- a/lua/hover.lua
+++ b/lua/hover.lua
@@ -47,6 +47,7 @@ end
 --- @param user_config Hover.UserConfig
 function M.config(user_config)
   require('hover.config').set(user_config)
+  require('hover.highlights').setup()
 end
 
 do -- deprecated

--- a/lua/hover/actions.lua
+++ b/lua/hover/actions.lua
@@ -46,7 +46,7 @@ local function make_title(active_provider_id, providers)
   local winbar_length = 0
 
   for _, p in ipairs(providers) do
-    ---@type HoverHighlightGroup
+    ---@type Hover.Highlight
     local hl = p.id == active_provider_id and 'HoverActiveSource' or 'HoverInactiveSource'
     title[#title + 1] = ('%%#%s# %s %%#HoverSourceLine#'):format(hl, p.name)
     winbar_length = winbar_length + #p.name + 2 -- + 2 for whitespace padding

--- a/lua/hover/actions.lua
+++ b/lua/hover/actions.lua
@@ -46,8 +46,9 @@ local function make_title(active_provider_id, providers)
   local winbar_length = 0
 
   for _, p in ipairs(providers) do
-    local hl = p.id == active_provider_id and 'TabLineSel' or 'TabLineFill'
-    title[#title + 1] = ('%%#%s# %s %%#Normal#'):format(hl, p.name)
+    ---@type HoverHighlightGroup
+    local hl = p.id == active_provider_id and 'HoverActiveSource' or 'HoverInactiveSource'
+    title[#title + 1] = ('%%#%s# %s %%#HoverSourceLine#'):format(hl, p.name)
     winbar_length = winbar_length + #p.name + 2 -- + 2 for whitespace padding
   end
 

--- a/lua/hover/highlights.lua
+++ b/lua/hover/highlights.lua
@@ -1,6 +1,6 @@
 local M = {}
 
----@alias HoverHighlightGroup
+---@alias Hover.Highlight
 ---| '"HoverWindow"'
 ---| '"HoverBorder"'
 ---| '"HoverActiveSource"'
@@ -11,7 +11,7 @@ local M = {}
 ---| '"HoverFloatingInfo"'
 ---| '"HoverFloatingHint"'
 
----@type table<HoverHighlightGroup, string>
+---@type table<Hover.Highlight, string>
 M.HIGHLIGHT_GROUP_DEFAULTS = {
   HoverWindow = 'NormalFloat',
   HoverBorder = 'FloatBorder',

--- a/lua/hover/highlights.lua
+++ b/lua/hover/highlights.lua
@@ -1,0 +1,37 @@
+local M = {}
+
+---@alias HoverHighlightGroup
+---| '"HoverWindow"'
+---| '"HoverBorder"'
+---| '"HoverActiveSource"'
+---| '"HoverInactiveSource"'
+---| '"HoverSourceLine"'
+---| '"HoverFloatingError"'
+---| '"HoverFloatingWarn"'
+---| '"HoverFloatingInfo"'
+---| '"HoverFloatingHint"'
+
+---@type table<HoverHighlightGroup, string>
+M.HIGHLIGHT_GROUP_DEFAULTS = {
+  HoverWindow = 'NormalFloat',
+  HoverBorder = 'FloatBorder',
+  HoverSourceLine = 'TabLine',
+  HoverActiveSource = 'TabLineSel',
+  HoverInactiveSource = 'TabLineFill',
+  HoverFloatingError = 'DiagnosticFloatingError',
+  HoverFloatingWarn = 'DiagnosticFloatingWarn',
+  HoverFloatingInfo = 'DiagnosticFloatingInfo',
+  HoverFloatingHint = 'DiagnosticFloatingHint',
+}
+
+function M.setup()
+  for highlight, value in pairs(M.HIGHLIGHT_GROUP_DEFAULTS) do
+    local existing = vim.api.nvim_get_hl(0, { name = highlight })
+
+    if vim.tbl_isempty(existing) then
+      vim.api.nvim_set_hl(0, highlight, { link = value })
+    end
+  end
+end
+
+return M

--- a/lua/hover/providers/diagnostic.lua
+++ b/lua/hover/providers/diagnostic.lua
@@ -4,11 +4,12 @@ local diagnostic = vim.diagnostic
 -- Most of this is taken straight from vim.diagnostic.open_float,
 -- with some tweaks to remove some unnecessary parts
 
+--- @type table<vim.diagnostic.Severity, HoverHighlightGroup>
 local highlight_map = {
-  [diagnostic.severity.ERROR] = 'DiagnosticFloatingError',
-  [diagnostic.severity.WARN] = 'DiagnosticFloatingWarn',
-  [diagnostic.severity.INFO] = 'DiagnosticFloatingInfo',
-  [diagnostic.severity.HINT] = 'DiagnosticFloatingHint',
+  [diagnostic.severity.ERROR] = 'HoverFloatingError',
+  [diagnostic.severity.WARN] = 'HoverFloatingWarn',
+  [diagnostic.severity.INFO] = 'HoverFloatingInfo',
+  [diagnostic.severity.HINT] = 'HoverFloatingHint',
 }
 
 --- @return vim.diagnostic.Opts.Float
@@ -158,12 +159,12 @@ local function execute(params, done)
     if type(prefix_opt) == 'function' then
       --- @cast prefix_opt fun(...): string?, string?
       local prefix0, prefix_hl_group0 = prefix_opt(d, i, #diagnostics)
-      prefix, prefix_hl_group = prefix0 or '', prefix_hl_group0 or 'NormalFloat'
+      prefix, prefix_hl_group = prefix0 or '', prefix_hl_group0 or 'HoverWindow'
     end
     if type(suffix_opt) == 'function' then
       --- @cast suffix_opt fun(...): string?, string?
       local suffix0, suffix_hl_group0 = suffix_opt(d, i, #diagnostics)
-      suffix, suffix_hl_group = suffix0 or '', suffix_hl_group0 or 'NormalFloat'
+      suffix, suffix_hl_group = suffix0 or '', suffix_hl_group0 or 'HoverWindow'
     end
     local message = d.message
     if source and d.source then

--- a/lua/hover/providers/diagnostic.lua
+++ b/lua/hover/providers/diagnostic.lua
@@ -4,7 +4,7 @@ local diagnostic = vim.diagnostic
 -- Most of this is taken straight from vim.diagnostic.open_float,
 -- with some tweaks to remove some unnecessary parts
 
---- @type table<vim.diagnostic.Severity, HoverHighlightGroup>
+--- @type table<vim.diagnostic.Severity, Hover.Highlight>
 local highlight_map = {
   [diagnostic.severity.ERROR] = 'HoverFloatingError',
   [diagnostic.severity.WARN] = 'HoverFloatingWarn',

--- a/lua/hover/util.lua
+++ b/lua/hover/util.lua
@@ -1,5 +1,7 @@
 local api = vim.api
 
+local highlight_defaults = require('hover.highlights').HIGHLIGHT_GROUP_DEFAULTS
+
 local M = {}
 
 --- @param winnr integer
@@ -376,6 +378,14 @@ function M.open_floating_preview(contents, bufnr, syntax, opts)
   local width, height = make_floating_popup_size(contents, opts)
   local float_opts = make_floating_popup_options(width, height, opts)
   local hover_winid = api.nvim_open_win(floating_bufnr, false, float_opts)
+
+  -- Set custom highlights for the window
+  local _winhl = {}
+  for hl, link in pairs(highlight_defaults) do
+    table.insert(_winhl, link .. ':' .. hl)
+  end
+  local winhl = table.concat(_winhl, ',')
+  api.nvim_set_option_value('winhl', winhl, { win = hover_winid })
 
   -- disable folding
   -- schedule so it runs after treesitter folding


### PR DESCRIPTION
This adds custom highlight groups for the hover window, and aliases them to the highlights used previously. With this patch, a user can create custom styles for the hover window that don't affect any other hover windows. With no customizations, it should look identical to before, with one exception: I switched the background of the source bar (`HoverSourceLine`) to use `TabLine` instead of `Normal`.

For the highlight names, I just picked what that felt right, but they could probably be improved. Additionally, `HoverSourceLine` could reasonably be `FloatTitle`, `TabLine`, or `WinBar`, but I picked `TabLine` since sources already use `TabLineSel` and `TabLineFill`.