### PR TITLE
Use mouse position for diagnostic and fold preview

### DIFF
--- a/lua/hover/actions.lua
+++ b/lua/hover/actions.lua
@@ -178,7 +178,7 @@ local function run_provider(provider, popts)
 
   popts = popts or {}
   popts.bufnr = popts.bufnr or api.nvim_get_current_buf()
-  popts.pos = popts.pos or vim.fn.getmousepos()
+  popts.pos = popts.pos or api.nvim_win_get_cursor(0)
 
   opts.relative = popts.relative
 

--- a/lua/hover/actions.lua
+++ b/lua/hover/actions.lua
@@ -155,14 +155,15 @@ end
 --- @param provider_id integer
 --- @param config Hover.Config
 --- @param result Hover.Result
---- @param opts Hover.Options
+--- @param popts Hover.Options
+--- @param float_opts table
 --- @return integer hover_winid
-local function show_hover(bufnr, provider_id, config, result, opts)
+local function show_hover(bufnr, provider_id, config, result, popts, float_opts)
   local util = require('hover.util')
-  local winid = util.open_floating_preview(result.lines, result.bufnr, result.filetype, opts)
+  local winid = util.open_floating_preview(result.lines, result.bufnr, result.filetype, float_opts)
 
   if config.title then
-    add_title(bufnr, winid, provider_id, opts)
+    add_title(bufnr, winid, provider_id, popts)
   end
   vim.w[winid].hover_provider = provider_id
 
@@ -192,7 +193,7 @@ local function run_provider(provider, popts)
 
   if result then
     async.scheduler()
-    show_hover(popts.bufnr, provider.id, config, result, opts)
+    show_hover(popts.bufnr, provider.id, config, result, popts, opts)
     return true
   end
 

--- a/lua/hover/actions.lua
+++ b/lua/hover/actions.lua
@@ -178,7 +178,7 @@ local function run_provider(provider, popts)
 
   popts = popts or {}
   popts.bufnr = popts.bufnr or api.nvim_get_current_buf()
-  popts.pos = popts.pos or api.nvim_win_get_cursor(0)
+  popts.pos = popts.pos or vim.fn.getmousepos()
 
   opts.relative = popts.relative
 

--- a/lua/hover/actions.lua
+++ b/lua/hover/actions.lua
@@ -14,15 +14,21 @@ local initialised = false
 
 --- @param provider Hover.Provider
 --- @param bufnr integer
+--- @param opts? Hover.Options
 --- @return boolean
-local function is_enabled(provider, bufnr)
-  return provider.enabled == nil or provider.enabled(bufnr)
+local function is_enabled(provider, bufnr, opts)
+  opts = opts or {}
+  opts.bufnr = opts.bufnr or bufnr
+  opts.pos = opts.pos or api.nvim_win_get_cursor(0)
+
+  return provider.enabled == nil or provider.enabled(opts.bufnr, opts)
 end
 
 --- @param bufnr integer
 --- @param winnr integer
 --- @param active_provider_id integer
-local function add_title(bufnr, winnr, active_provider_id)
+--- @param opts Hover.Options
+local function add_title(bufnr, winnr, active_provider_id, opts)
   if not has_winbar then
     vim.notify_once('hover.nvim: `config.title` requires neovim >= 0.8.0', vim.log.levels.WARN)
     return
@@ -33,7 +39,7 @@ local function add_title(bufnr, winnr, active_provider_id)
   local winbar_length = 0
 
   for _, p in ipairs(providers) do
-    if is_enabled(p, bufnr) then
+    if is_enabled(p, bufnr, opts) then
       local hl = p.id == active_provider_id and 'TabLineSel' or 'TabLineFill'
       title[#title + 1] = string.format('%%#%s# %s ', hl, p.name)
       title[#title + 1] = '%#Normal# '
@@ -156,7 +162,7 @@ local function show_hover(bufnr, provider_id, config, result, opts)
   local winid = util.open_floating_preview(result.lines, result.bufnr, result.filetype, opts)
 
   if config.title then
-    add_title(bufnr, winid, provider_id)
+    add_title(bufnr, winid, provider_id, opts)
   end
   vim.w[winid].hover_provider = provider_id
 
@@ -233,7 +239,7 @@ M.hover = async.void(function(opts)
   for _, provider in ipairs(providers) do
     if not opts or not opts.providers or vim.tbl_contains(opts.providers, provider.name) then
       async.scheduler()
-      if use_provider and is_enabled(provider, bufnr) and run_provider(provider, opts) then
+      if use_provider and is_enabled(provider, bufnr, opts) and run_provider(provider, opts) then
         return
       end
       if provider.id == current_provider then
@@ -245,7 +251,7 @@ M.hover = async.void(function(opts)
   for _, provider in ipairs(providers) do
     if not opts or not opts.providers or vim.tbl_contains(opts.providers, provider.name) then
       async.scheduler()
-      if is_enabled(provider, bufnr) and run_provider(provider, opts) then
+      if is_enabled(provider, bufnr, opts) and run_provider(provider, opts) then
         return
       end
     end
@@ -269,7 +275,7 @@ function M.hover_switch(direction, opts)
     if p.id == current_provider then
       provider_idx = provider_count
     end
-    if is_enabled(p, bufnr) then
+    if is_enabled(p, bufnr, opts) then
       active_providers[provider_count] = n
       provider_count = provider_count + 1
     end
@@ -299,7 +305,7 @@ function M.hover_select(opts)
     --- @param provider Hover.Provider
     --- @return boolean
     vim.tbl_filter(function(provider)
-      return is_enabled(provider, bufnr)
+      return is_enabled(provider, bufnr, opts)
     end, providers),
     {
       prompt = 'Select hover:',

--- a/lua/hover/providers.lua
+++ b/lua/hover/providers.lua
@@ -12,7 +12,7 @@ local M = {}
 --- @field priority integer
 --- @field name string
 --- @field execute fun(opts?: Hover.Options, done: fun(result?: false|Hover.Result))
---- @field enabled fun(bufnr: integer): boolean
+--- @field enabled fun(bufnr: integer, opts?: Hover.Options): boolean
 
 --- @class Hover.Provider : Hover.RegisterProvider
 --- @field id integer

--- a/lua/hover/providers/diagnostic.lua
+++ b/lua/hover/providers/diagnostic.lua
@@ -71,11 +71,12 @@ local function filter_diagnostics(diagnostics, lnum, col, bufnr)
 end
 
 --- @param bufnr integer
+--- @param opts? Hover.Options
 --- @return boolean
-local function enabled(bufnr)
+local function enabled(bufnr, opts)
   local buffer_diagnostics = vim.diagnostic.get(bufnr)
-  local pos = vim.fn.getmousepos()
-  local lnum, col = pos.line - 1, pos.column
+  local pos = opts and opts.pos or api.nvim_win_get_cursor(0)
+  local lnum, col = pos[1] - 1, pos[2]
   local diagnostics = filter_diagnostics(buffer_diagnostics, lnum, col, bufnr)
   return #diagnostics ~= 0
 end

--- a/lua/hover/providers/diagnostic.lua
+++ b/lua/hover/providers/diagnostic.lua
@@ -39,15 +39,14 @@ local function count_sources(diagnostics)
 end
 
 --- @param diagnostics vim.Diagnostic[]
+--- @param lnum integer
+--- @param col integer
 --- @param bufnr integer
 --- @return vim.Diagnostic[]
-local function filter_diagnostics(diagnostics, bufnr)
+local function filter_diagnostics(diagnostics, lnum, col, bufnr)
   local float_opts = get_float_opts()
   local scope = float_opts.scope or 'line'
 
-  local pos = api.nvim_win_get_cursor(0)
-  local lnum = pos[1] - 1
-  local col = pos[2]
   if scope == 'line' then
     --- @param d vim.Diagnostic
     --- @return boolean
@@ -75,7 +74,9 @@ end
 --- @return boolean
 local function enabled(bufnr)
   local buffer_diagnostics = vim.diagnostic.get(bufnr)
-  local diagnostics = filter_diagnostics(buffer_diagnostics, bufnr)
+  local pos = vim.fn.getmousepos()
+  local lnum, col = pos.line - 1, pos.column
+  local diagnostics = filter_diagnostics(buffer_diagnostics, lnum, col, bufnr)
   return #diagnostics ~= 0
 end
 
@@ -83,7 +84,8 @@ end
 --- @param done fun(result?: Hover.Result)
 local function execute(opts, done)
   local buffer_diagnostics = vim.diagnostic.get(opts.bufnr)
-  local diagnostics = filter_diagnostics(buffer_diagnostics, opts.bufnr)
+  local lnum, col = opts.pos[1] - 1, opts.pos[2]
+  local diagnostics = filter_diagnostics(buffer_diagnostics, lnum, col, opts.bufnr)
 
   local float_opts = get_float_opts()
 

--- a/lua/hover/providers/fold_preview.lua
+++ b/lua/hover/providers/fold_preview.lua
@@ -29,10 +29,12 @@ set_border_shift(config.preview_opts.border)
 hover.register({
   name = 'Fold Preview',
   enabled = function()
-    return fn.foldclosed(fn.line('.')) ~= -1
+    local mousepos = fn.getmousepos()
+    local lnum = mousepos.line - 1
+    return fn.foldclosed(lnum) ~= -1
   end,
-  execute = function(_opts, done)
-    local cur_line = fn.line('.')
+  execute = function(opts, done)
+    local cur_line = opts.pos[1] - 1
     local fold_start = fn.foldclosed(cur_line)
     local fold_end = fn.foldclosedend(cur_line)
 

--- a/lua/hover/providers/fold_preview.lua
+++ b/lua/hover/providers/fold_preview.lua
@@ -28,9 +28,9 @@ set_border_shift(config.preview_opts.border)
 
 hover.register({
   name = 'Fold Preview',
-  enabled = function()
-    local mousepos = fn.getmousepos()
-    local lnum = mousepos.line
+  enabled = function(_bufnr, opts)
+    local pos = opts and opts.pos or api.nvim_win_get_cursor(0)
+    local lnum = pos[1]
     return fn.foldclosed(lnum) ~= -1
   end,
   execute = function(opts, done)

--- a/lua/hover/providers/fold_preview.lua
+++ b/lua/hover/providers/fold_preview.lua
@@ -30,11 +30,11 @@ hover.register({
   name = 'Fold Preview',
   enabled = function()
     local mousepos = fn.getmousepos()
-    local lnum = mousepos.line - 1
+    local lnum = mousepos.line
     return fn.foldclosed(lnum) ~= -1
   end,
   execute = function(opts, done)
-    local cur_line = opts.pos[1] - 1
+    local cur_line = opts.pos[1]
     local fold_start = fn.foldclosed(cur_line)
     local fold_end = fn.foldclosedend(cur_line)
 


### PR DESCRIPTION
Fixes #73

Now diagnostic and fold preview show information from under the mouse on hover, not under the cursor.

I haven't changed the other providers (which also have this bug) since they depend on the cursor to get information (i.e. `<cword>`). Those could require a larger refactor.

More generally, all providers seem to only work with the current window, whereas, in a window split, the current window might not be the window the mouse is hovering on, returning wrong information. Fixing this would be best done in a separate PR as the changes would be quite large.

So, for this PR, I try to bring the most value for the smallest changes. Let me know if any further changes are needed.