### PR TITLE
fix: line may be nil when moving cursor up/down outside terminal

### DIFF
--- a/lua/hover/providers/lsp.lua
+++ b/lua/hover/providers/lsp.lua
@@ -56,7 +56,12 @@ local function create_params(bufnr, row, col)
     end
 
     local line = lines[1]
-    col = math.min(col, #line)
+	if line then
+		col = math.min(col, #line)
+	else
+		line = ""
+	end
+
 
     return {
       textDocument = { uri = vim.uri_from_bufnr(bufnr) },


### PR DESCRIPTION
When moving cursor outside from the terminal from up or down direction, I met the following error:
![Screenshot_20250402_152731](https://github.com/user-attachments/assets/2ab9e90a-99f4-45a4-bfbb-13414eb6bdf7)

it seems that variable `line` may be `nil`. In that case, I change line into empty string. This solve the issue. Not sure if it has any side effects.