### PR TITLE
Hide hover title when only one provider available

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ use {
             -- to a :h preview-window when pressing the hover keymap.
             preview_window = false,
             title = true,
+            -- title = { contextual = true },  -- Hides title when there's only one provider
             mouse_providers = {
                 'LSP'
             },

--- a/lua/hover/actions.lua
+++ b/lua/hover/actions.lua
@@ -28,7 +28,8 @@ end
 --- @param winnr integer
 --- @param active_provider_id integer
 --- @param opts Hover.Options
-local function add_title(bufnr, winnr, active_provider_id, opts)
+--- @param contextual boolean
+local function add_title(bufnr, winnr, active_provider_id, opts, contextual)
   if not has_winbar then
     vim.notify_once('hover.nvim: `config.title` requires neovim >= 0.8.0', vim.log.levels.WARN)
     return
@@ -45,6 +46,10 @@ local function add_title(bufnr, winnr, active_provider_id, opts)
       title[#title + 1] = '%#Normal# '
       winbar_length = winbar_length + #p.name + 2 -- + 2 for whitespace padding
     end
+  end
+
+  if #title <= 2 and contextual then
+    return
   end
 
   local config = api.nvim_win_get_config(winnr)
@@ -163,7 +168,8 @@ local function show_hover(bufnr, provider_id, config, result, popts, float_opts)
   local winid = util.open_floating_preview(result.lines, result.bufnr, result.filetype, float_opts)
 
   if config.title then
-    add_title(bufnr, winid, provider_id, popts)
+    local contextual = type(config.title) == "table" and config.title.contextual
+    add_title(bufnr, winid, provider_id, popts, contextual)
   end
   vim.w[winid].hover_provider = provider_id
 

--- a/lua/hover/actions.lua
+++ b/lua/hover/actions.lua
@@ -168,7 +168,7 @@ local function show_hover(bufnr, provider_id, config, result, popts, float_opts)
   local winid = util.open_floating_preview(result.lines, result.bufnr, result.filetype, float_opts)
 
   if config.title then
-    local contextual = type(config.title) == "table" and config.title.contextual
+    local contextual = type(config.title) == 'table' and config.title.contextual
     add_title(bufnr, winid, provider_id, popts, contextual)
   end
   vim.w[winid].hover_provider = provider_id

--- a/lua/hover/config.lua
+++ b/lua/hover/config.lua
@@ -14,7 +14,7 @@ local default_config = {
 }
 
 --- @class Hover.UserConfig: Hover.Config
---- @field title? boolean
+--- @field title? boolean | table
 --- @field mouse_providers? string[]
 --- @field mouse_delay? integer
 --- @field preview_opts? table


### PR DESCRIPTION
This adds the option to contextually hide the hover window's title when only one provider is available.

All previously valid user configurations are still valid, however the user can optionally set the `title` field to `{ contextual = true }` if they wish to use this feature.

Resolves #86