### PR TITLE
fix(providers): Fix crash, respect buffer repository

### DIFF
--- a/lua/hover/providers/gh.lua
+++ b/lua/hover/providers/gh.lua
@@ -72,7 +72,7 @@ local function execute(_opts, done)
     else
       num = word:match('#(%d+)')
       if num then
-        obj = async.await(vim.system, {
+        obj = async.await(3, vim.system, {
           'gh',
           'issue',
           'view',

--- a/lua/hover/providers/gh.lua
+++ b/lua/hover/providers/gh.lua
@@ -67,8 +67,7 @@ local function execute(_opts, done)
         num,
         '-R',
         repo,
-        cwd = cwd,
-      })
+      }, { cwd = cwd })
     else
       num = word:match('#(%d+)')
       if num then
@@ -79,8 +78,7 @@ local function execute(_opts, done)
           '--json',
           fields,
           id,
-          cwd = cwd,
-        })
+        }, { cwd = cwd })
       else
         done(false)
         return

--- a/lua/hover/providers/gh_user.lua
+++ b/lua/hover/providers/gh_user.lua
@@ -82,7 +82,7 @@ local function execute(_opts, done)
     done(false)
   end
 
-  vim.system({ 'gh', 'api', 'users/' .. user, cwd = cwd }, {}, function(out)
+  vim.system({ 'gh', 'api', 'users/' .. user }, { cwd = cwd }, function(out)
     local results = process(out.stdout, out.stderr)
     done(results and { lines = results, filetype = 'markdown' })
   end)


### PR DESCRIPTION
Thanks for this nice plugin!

The recent migration to the new async framework in https://github.com/lewis6991/hover.nvim/commit/fdc5b4fc3f5300c87fbde16cab0aeb122ba6324a missed two minor adjustments.

This causes two issues:

1. The `gh` provider crashes when querying issues for the current repository since `vim.system` receives the callback in place of `cmd`:

> vim/\_system.lua:330: cmd: expected table, got function

2. Both `gh` and `gh_users` providers always run the `gh` CLI in nvim's `current-directory`, not the directory that contains the current buffer. This can cause missing/wrong issues to be returned. Unsure about the impact on `gh_users`.

Hope submitting this is fine and I did everything correctly. Cheers!
