### PR TITLE
fix(fold_preview): avoid unintended `error()` call.

### DIFF
--- a/lua/hover/providers/fold_preview.lua
+++ b/lua/hover/providers/fold_preview.lua
@@ -10,15 +10,20 @@ local function set_border_shift(border)
   if type(border) == 'string' then
     if border == 'none' then
       border_shift = { 0, 0, 0, 0 }
+      return
     elseif vim.tbl_contains({ 'single', 'double', 'rounded', 'solid' }, border) then
       border_shift = { -1, -1, -1, -1 }
+      return
     elseif border == 'shadow' then
       border_shift = { 0, -1, -1, 0 }
+      return
     end
+    -- error() if `border` matches non of the values above
   elseif type(border) == 'table' then
     for i = 1, 4 do
       border_shift[i] = border[i * 2] == '' and 0 or -1
     end
+    return
   end
   error('Invalid border type or value')
 end


### PR DESCRIPTION
The recent refactor (f72ca72) introduced a bug in the [`fold_preview`](https://github.com/lewis6991/hover.nvim/blob/f72ca72baeecad87110a8b232ce5bcce12643289/lua/hover/providers/fold_preview.lua#L23) provider, where the `error()` is always called regardless of whether the `border` parameter is valid. This patch fixes the error.