### PR TITLE
fix: split strings containing newlines into separate buf lines

### DIFF
--- a/lua/hover/util.lua
+++ b/lua/hover/util.lua
@@ -63,6 +63,23 @@ local function trim_empty_lines(lines)
   return vim.list_extend({}, lines, start, finish)
 end
 
+--- @param lines string[]
+--- @return string[]
+local function normalize_new_lines(lines)
+  local result = {}
+  for _, item in ipairs(lines) do
+    item = item:gsub('\r\n', '\n')
+    if item:sub(-1) ~= '\n' then
+      item = item .. '\n'
+    end
+    for line in item:gmatch('(.-)\n') do
+      table.insert(result, line)
+    end
+  end
+
+  return result
+end
+
 --- @param width integer
 --- @param height integer
 --- @param opts vim.api.keyset.win_config
@@ -344,8 +361,10 @@ function M.open_floating_preview(contents, bufnr, syntax, opts)
   -- if contents given, always set buf lines
   -- if no bufnr, contents is required
   if contents or not bufnr then
+    --- Split strings witn new lines into separate buf lines
+    contents = normalize_new_lines(assert(contents))
     -- Clean up input: trim empty lines from the end, pad
-    contents = trim_empty_lines(assert(contents))
+    contents = trim_empty_lines(contents)
 
     if syntax == 'markdown' then
       -- applies the syntax and sets the lines to the buffer


### PR DESCRIPTION
Some LSPs could emit hovers containing newlines. In this case `vim.nvim_buf_set_lines` raises errors. Example: helm_ls attached to buffer outside of helm root dir.
<img width="1269" height="226" alt="image" src="https://github.com/user-attachments/assets/a44659e0-ecac-4d22-8557-30a62218888d" />

After fix it will correctly render hover.
<img width="2126" height="307" alt="image" src="https://github.com/user-attachments/assets/6a7ebfb7-2009-4cd2-aed3-8df748975284" />

