### PR TITLE
Fix for #100 - [Bug] hover.switch is broken

### DIFF
--- a/lua/hover/actions.lua
+++ b/lua/hover/actions.lua
@@ -297,7 +297,7 @@ function M.switch(direction, opts)
   for i, p in ipairs(providers) do
     if p.id == current_provider_id then
       current_provider_idx = i
-      return
+      break
     end
   end
 


### PR DESCRIPTION
Basically a typo fix, function was prematurely returning when it identified the next provider to switch too. This replaces that return with a break; upon determining the provider to switch to function proceeds to the actual switch instead of exiting.