### PR TITLE
feat: add option to control no response window

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ require('hover').config({
   -- Whether the contents of a currently open hover window should be moved
   -- to a :h preview-window when pressing the hover keymap.
   preview_window = false,
+
+  -- Whether to show the hover window when a provider has no result.
+  show_no_result = false,
+
   title = true,
   mouse_providers = {
     'hover.providers.lsp',

--- a/lua/hover/actions.lua
+++ b/lua/hover/actions.lua
@@ -200,7 +200,13 @@ local function run_provider(provider, providers, bufnr, popts)
   local result = async.await(2, provider.execute, {
     bufnr = bufnr,
     pos = popts.pos or api.nvim_win_get_cursor(0),
-  }) or { lines = { 'No result' } }
+  })
+
+  if not config.show_no_result and not result then
+    return false
+  end
+
+  result = result or { lines = { 'No result' } }
 
   async.scheduler()
   show_hover(provider.id, providers, config, result, opts)

--- a/lua/hover/config.lua
+++ b/lua/hover/config.lua
@@ -13,6 +13,7 @@ local default_config = {
     border = 'single',
   },
   preview_window = false,
+  show_no_result = false,
   title = true,
   mouse_delay = 1000,
   --- @type (string|Hover.Config.Provider)[]
@@ -31,6 +32,9 @@ local default_config = {
 --- Whether the contents of a currently open hover window should be moved
 --- to a :h preview-window when pressing the hover keymap.
 --- @field preview_window? boolean
+---
+--- Whether to show the hover window when a provider has no result.
+--- @field show_no_result? boolean
 ---
 --- @field title? boolean
 ---


### PR DESCRIPTION
Adds a new configuration option 'show_no_result' that allows users to control whether the hover window is displayed when a provider returns no result.

When set to 'false' (default), providers with no result are skipped. When set to 'true', displays the hover window with "No result" message.

Closes #103 and #110.